### PR TITLE
fix: crash when stream-json events have undefined content

### DIFF
--- a/electron/packages/frontend/src/components/StreamJsonViewer.tsx
+++ b/electron/packages/frontend/src/components/StreamJsonViewer.tsx
@@ -209,7 +209,7 @@ export const StreamJsonViewer = React.memo(function StreamJsonViewer({
     return parsedEvents
       .filter((e): e is AssistantEvent => e.type === "assistant")
       .flatMap((e) =>
-        e.content.filter((c): c is TextContent => c.type === "text")
+        (e.content || []).filter((c): c is TextContent => c.type === "text")
       )
       .map((c) => c.text);
   }, [parsedEvents]);
@@ -226,7 +226,7 @@ export const StreamJsonViewer = React.memo(function StreamJsonViewer({
     for (const event of parsedEvents) {
       if (event.type === "assistant") {
         const assistantEvent = event as AssistantEvent;
-        for (const c of assistantEvent.content) {
+        for (const c of assistantEvent.content || []) {
           if (c.type === "tool_use") {
             const toolUse = c as ToolUseContent;
             calls.push({
@@ -238,7 +238,7 @@ export const StreamJsonViewer = React.memo(function StreamJsonViewer({
         }
       } else if (event.type === "user") {
         const userEvent = event as UserEvent;
-        for (const c of userEvent.content) {
+        for (const c of userEvent.content || []) {
           if (c.type === "tool_result") {
             const toolResult = c as ToolResultContent;
             const call = calls.find((tc) => tc.id === toolResult.tool_use_id);


### PR DESCRIPTION
## Summary
- Fixed `TypeError: Cannot read properties of undefined (reading 'filter')` crash in StreamJsonViewer
- Some Claude CLI stream-json events have `content` as undefined rather than an array
- Added defensive guards (`|| []`) at all three content access points in the component

## Changes
| File | Change |
|------|--------|
| `electron/packages/frontend/src/components/StreamJsonViewer.tsx` | Guard `content` with `|| []` in textMessages memo, toolCalls assistant loop, and toolCalls user loop |

🤖 Generated with [Claude Code](https://claude.com/claude-code)