### PR TITLE
fix: crash in ALL PARSED view when stream events have undefined content

### DIFF
--- a/electron/packages/frontend/src/components/StreamJsonViewer.tsx
+++ b/electron/packages/frontend/src/components/StreamJsonViewer.tsx
@@ -408,17 +408,17 @@ export const StreamJsonViewer = React.memo(function StreamJsonViewer({
                   }
                   if (event.type === "assistant") {
                     const asst = event as AssistantEvent;
-                    const textCount = asst.content.filter(
+                    const textCount = (asst.content || []).filter(
                       (c) => c.type === "text"
                     ).length;
-                    const toolCount = asst.content.filter(
+                    const toolCount = (asst.content || []).filter(
                       (c) => c.type === "tool_use"
                     ).length;
                     return `${textCount} text, ${toolCount} tool(s)`;
                   }
                   if (event.type === "user") {
                     const usr = event as UserEvent;
-                    return `${usr.content.length} tool result(s)`;
+                    return `${(usr.content || []).length} tool result(s)`;
                   }
                   if (event.type === "result") {
                     const res = event as ResultEvent;


### PR DESCRIPTION
## Summary
- Fixed remaining `TypeError: Cannot read properties of undefined (reading 'filter')` crash in StreamJsonViewer
- The previous fix (v1.5.2) guarded the useMemo hooks but missed three `.content` accesses in the ALL PARSED view's summary rendering function
- Added `|| []` guards to all remaining unprotected content accesses

## Changes
| File | Change |
|------|--------|
| `electron/packages/frontend/src/components/StreamJsonViewer.tsx` | Guard `.content` in ALL PARSED summary for assistant text/tool counts and user result count |

🤖 Generated with [Claude Code](https://claude.com/claude-code)