### PR TITLE
Fix variable overrides truncating at newline characters

### DIFF
--- a/acs/src/cli/jobs.rs
+++ b/acs/src/cli/jobs.rs
@@ -508,7 +508,10 @@ async fn follow_sse_stream(response: reqwest::Response) -> anyhow::Result<()> {
                 if let Some(rest) = line.strip_prefix("event: ") {
                     event_type = rest.to_string();
                 } else if let Some(rest) = line.strip_prefix("data: ") {
-                    data = rest.to_string();
+                    if !data.is_empty() {
+                        data.push('\n');
+                    }
+                    data.push_str(rest);
                 }
             }
 

--- a/acs/src/cli/jobs.rs
+++ b/acs/src/cli/jobs.rs
@@ -566,6 +566,37 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_sse_data_accumulation() {
+        // Simulate multi-line SSE data parsing
+        let event_block = "event: output\ndata: {\"line\":\ndata: \"hello\"}\n";
+        let mut data = String::new();
+        for line in event_block.lines() {
+            if let Some(rest) = line.strip_prefix("data: ") {
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(rest);
+            }
+        }
+        assert_eq!(data, "{\"line\":\n\"hello\"}");
+    }
+
+    #[test]
+    fn test_sse_single_data_line() {
+        let event_block = "event: output\ndata: {\"msg\":\"hello\"}\n";
+        let mut data = String::new();
+        for line in event_block.lines() {
+            if let Some(rest) = line.strip_prefix("data: ") {
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(rest);
+            }
+        }
+        assert_eq!(data, "{\"msg\":\"hello\"}");
+    }
+
+    #[test]
     fn test_format_relative_time_past() {
         let past = Utc::now() - chrono::Duration::minutes(5);
         let result = format_relative_time(&past);

--- a/acs/src/cli/logs.rs
+++ b/acs/src/cli/logs.rs
@@ -264,7 +264,10 @@ async fn follow_sse_logs(client: &Client, url: &str) -> anyhow::Result<()> {
                 if let Some(rest) = line.strip_prefix("event: ") {
                     event_type = rest.to_string();
                 } else if let Some(rest) = line.strip_prefix("data: ") {
-                    data = rest.to_string();
+                    if !data.is_empty() {
+                        data.push('\n');
+                    }
+                    data.push_str(rest);
                 }
             }
 

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -1965,4 +1965,124 @@ mod tests {
         let deserialized: JobRun = serde_json::from_str(&json).expect("deserialize");
         assert!(deserialized.trigger_params.is_none());
     }
+
+    #[tokio::test]
+    async fn test_build_command_trigger_args_newline_sanitized() {
+        let now = Utc::now();
+        let job = Job {
+            id: Uuid::now_v7(),
+            name: "newline-test".to_string(),
+            schedule: "*/5 * * * *".to_string(),
+            execution: ExecutionType::ShellCommand("echo hello".to_string()),
+            enabled: true,
+            timezone: None,
+            working_dir: None,
+            env_vars: None,
+            timeout_secs: 0,
+            log_environment: false,
+            created_at: now,
+            updated_at: now,
+            last_run_at: None,
+            last_exit_code: None,
+            next_run_at: None,
+        };
+
+        let cmd = Executor::build_command(&job, Some("--flag\n--other"), None);
+        let args = cmd.get_argv();
+
+        // The trigger args newline should be replaced with a space in the final command string
+        let full_cmd = args[2].to_string_lossy();
+        assert!(
+            !full_cmd.contains('\n'),
+            "Command should not contain newline. Got: {:?}",
+            full_cmd
+        );
+        assert!(
+            full_cmd.contains("--flag --other"),
+            "Newline should be replaced with space. Got: {:?}",
+            full_cmd
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_command_trigger_args_crlf_sanitized() {
+        let now = Utc::now();
+        let job = Job {
+            id: Uuid::now_v7(),
+            name: "crlf-test".to_string(),
+            schedule: "*/5 * * * *".to_string(),
+            execution: ExecutionType::ShellCommand("echo hello".to_string()),
+            enabled: true,
+            timezone: None,
+            working_dir: None,
+            env_vars: None,
+            timeout_secs: 0,
+            log_environment: false,
+            created_at: now,
+            updated_at: now,
+            last_run_at: None,
+            last_exit_code: None,
+            next_run_at: None,
+        };
+
+        let cmd = Executor::build_command(&job, Some("--flag\r\n--other"), None);
+        let args = cmd.get_argv();
+
+        // The trigger args CRLF should be replaced with spaces in the final command string
+        let full_cmd = args[2].to_string_lossy();
+        assert!(
+            !full_cmd.contains('\n'),
+            "Command should not contain newline. Got: {:?}",
+            full_cmd
+        );
+        assert!(
+            !full_cmd.contains('\r'),
+            "Command should not contain carriage return. Got: {:?}",
+            full_cmd
+        );
+        assert!(
+            full_cmd.contains("--flag") && full_cmd.contains("--other"),
+            "Both flags should be present. Got: {:?}",
+            full_cmd
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_command_script_trigger_args_newline_sanitized() {
+        let now = Utc::now();
+        let job = Job {
+            id: Uuid::now_v7(),
+            name: "script-newline-test".to_string(),
+            schedule: "*/5 * * * *".to_string(),
+            execution: ExecutionType::ScriptFile("deploy.sh".to_string()),
+            enabled: true,
+            timezone: None,
+            working_dir: None,
+            env_vars: None,
+            timeout_secs: 0,
+            log_environment: false,
+            created_at: now,
+            updated_at: now,
+            last_run_at: None,
+            last_exit_code: None,
+            next_run_at: None,
+        };
+
+        let cmd = Executor::build_command(&job, Some("--env\nprod"), None);
+        let args = cmd.get_argv();
+
+        // The final command argument (index 1 on unix with trigger args uses -c, index 2 is the cmd string)
+        // On Windows it's args[2] as well. Either way, no newlines should appear.
+        let full_cmd = args.last().unwrap().to_string_lossy();
+        assert!(
+            !full_cmd.contains('\n'),
+            "Script command should not contain newline. Got: {:?}",
+            full_cmd
+        );
+        assert!(
+            full_cmd.contains("--env") && full_cmd.contains("prod"),
+            "Both parts of args should be present. Got: {:?}",
+            full_cmd
+        );
+    }
 }

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -56,7 +56,7 @@ impl Executor {
             ExecutionType::ShellCommand(command) => {
                 let effective_command = match trigger_args {
                     Some(args) => {
-                        let sanitized = args.replace('\n', " ").replace('\r', " ");
+                        let sanitized = args.replace(['\n', '\r'], " ");
                         format!("{} {}", command, sanitized)
                     }
                     None => command.clone(),
@@ -76,7 +76,7 @@ impl Executor {
             ExecutionType::ScriptFile(script) => {
                 let effective_script = match trigger_args {
                     Some(args) => {
-                        let sanitized = args.replace('\n', " ").replace('\r', " ");
+                        let sanitized = args.replace(['\n', '\r'], " ");
                         format!("{} {}", script, sanitized)
                     }
                     None => script.clone(),

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -55,7 +55,10 @@ impl Executor {
         let mut cmd = match &job.execution {
             ExecutionType::ShellCommand(command) => {
                 let effective_command = match trigger_args {
-                    Some(args) => format!("{} {}", command, args),
+                    Some(args) => {
+                        let sanitized = args.replace('\n', " ").replace('\r', " ");
+                        format!("{} {}", command, sanitized)
+                    }
                     None => command.clone(),
                 };
                 if cfg!(target_os = "windows") {
@@ -72,7 +75,10 @@ impl Executor {
             }
             ExecutionType::ScriptFile(script) => {
                 let effective_script = match trigger_args {
-                    Some(args) => format!("{} {}", script, args),
+                    Some(args) => {
+                        let sanitized = args.replace('\n', " ").replace('\r', " ");
+                        format!("{} {}", script, sanitized)
+                    }
                     None => script.clone(),
                 };
                 if cfg!(target_os = "windows") {


### PR DESCRIPTION
## Summary
- Fix SSE data line parsing in CLI to properly accumulate multi-line data per the SSE spec, preventing output truncation
- Sanitize newline characters in trigger args before shell command concatenation to prevent shell truncation
- Closes #46

## Changes
| File | Change |
|------|--------|
| acs/src/cli/jobs.rs | Fix SSE `data:` accumulation — append with newline separator instead of overwriting |
| acs/src/cli/logs.rs | Same SSE `data:` accumulation fix for log streaming |
| acs/src/daemon/executor.rs | Sanitize `\n`/`\r` in trigger args before shell command concatenation |

## AI Suggested Testing Plan
- [ ] Trigger a job with multi-line output (e.g., `printf "line1\nline2\nline3"`) and verify all lines appear when using `--follow`
- [ ] Trigger a job with `--args` containing a newline character and verify the full args string is passed to the command
- [ ] Run `cargo test` from `acs/` — all 345 tests should pass
- [ ] Follow logs with `acs logs --follow` and verify multi-line output is not truncated

## Ticket
#46 — https://github.com/Jtonna/agent-cron-scheduler/issues/46

---
Generated by the starterpack orchestrator.