### PR TITLE
Fix service registration, PATH setup, and React UI filter error

### DIFF
--- a/acs/src/cli/daemon.rs
+++ b/acs/src/cli/daemon.rs
@@ -36,17 +36,32 @@ pub async fn cmd_start(
     // Register scheduled task for auto-start at logon (if not already)
     if !service::is_service_registered() {
         println!("Registering auto-start task...");
+        tracing::info!("Registering auto-start task...");
         if let Err(e) = service::install_service(&exe_path) {
             eprintln!("Warning: Could not register auto-start: {}", e);
             eprintln!("The daemon will start now but won't persist across reboots.");
             eprintln!("You may need elevated privileges to register the task.");
+            tracing::warn!("Could not register auto-start: {}", e);
+            tracing::warn!("The daemon will start now but won't persist across reboots.");
+            tracing::warn!("You may need elevated privileges to register the task.");
         } else {
             println!(
                 "Auto-start registered ({} on {}).",
                 service::service_name(),
                 service::platform_name()
             );
+            tracing::info!(
+                "Auto-start registered ({} on {}).",
+                service::service_name(),
+                service::platform_name()
+            );
         }
+    }
+
+    // Ensure the binary's directory is in the user's PATH regardless of whether
+    // service registration succeeded — PATH registration is independent.
+    if let Err(e) = service::ensure_path_entry(&exe_path) {
+        tracing::warn!("Could not add binary to PATH: {}", e);
     }
 
     // Quick check: is the daemon already running?

--- a/acs/src/daemon/service.rs
+++ b/acs/src/daemon/service.rs
@@ -73,6 +73,7 @@ mod platform {
         // so the task completes quickly while the daemon runs independently.
         let tr = format!("\"{}\" start", exe);
 
+        // First attempt: with /RL HIGHEST (requires elevation).
         let status = std::process::Command::new("schtasks")
             .args([
                 "/Create", "/TN", TASK_NAME, "/TR", &tr, "/SC", "ONLOGON", "/RL", "HIGHEST", "/F",
@@ -81,12 +82,30 @@ mod platform {
             .context("Failed to run schtasks")?;
 
         if status.success() {
-            if let Err(e) = ensure_path_entry(exe_path) {
-                tracing::warn!("Could not add binary to PATH: {}", e);
-            }
+            return Ok(());
+        }
+
+        // Fallback: retry without /RL HIGHEST so non-elevated users can still
+        // register the task (it will run at normal privilege level).
+        tracing::warn!(
+            "schtasks /Create with /RL HIGHEST failed (exit code {:?}), retrying without elevation",
+            status.code()
+        );
+
+        let status_fallback = std::process::Command::new("schtasks")
+            .args([
+                "/Create", "/TN", TASK_NAME, "/TR", &tr, "/SC", "ONLOGON", "/F",
+            ])
+            .status()
+            .context("Failed to run schtasks (fallback)")?;
+
+        if status_fallback.success() {
             Ok(())
         } else {
-            anyhow::bail!("schtasks /Create failed (exit code {:?})", status.code())
+            anyhow::bail!(
+                "schtasks /Create failed (exit code {:?})",
+                status_fallback.code()
+            )
         }
     }
 
@@ -248,7 +267,7 @@ mod platform {
     }
 
     /// Ensure the executable's directory is in the user's PATH by modifying shell config files.
-    fn ensure_path_entry(exe_path: &Path) -> anyhow::Result<()> {
+    pub fn ensure_path_entry(exe_path: &Path) -> anyhow::Result<()> {
         use std::io::{BufRead, BufReader};
 
         let exe_dir = exe_path
@@ -345,11 +364,6 @@ mod platform {
             .arg(plist_path())
             .status();
 
-        // Best-effort PATH modification
-        if let Err(e) = ensure_path_entry(exe_path) {
-            tracing::warn!("Failed to add PATH entry: {}", e);
-        }
-
         Ok(())
     }
 
@@ -424,7 +438,7 @@ mod platform {
     }
 
     /// Ensure the executable's directory is in the user's PATH by modifying shell config files.
-    fn ensure_path_entry(exe_path: &Path) -> anyhow::Result<()> {
+    pub fn ensure_path_entry(exe_path: &Path) -> anyhow::Result<()> {
         use std::io::{BufRead, BufReader};
 
         let exe_dir = exe_path
@@ -528,11 +542,6 @@ WantedBy=default.target
             .arg("enable-linger")
             .status();
 
-        // Best-effort PATH modification
-        if let Err(e) = ensure_path_entry(exe_path) {
-            tracing::warn!("Failed to add PATH entry: {}", e);
-        }
-
         Ok(())
     }
 
@@ -615,6 +624,11 @@ pub fn is_service_registered() -> bool {
 /// Install the system service for the current platform.
 pub fn install_service(exe_path: &Path) -> anyhow::Result<()> {
     platform::install_service(exe_path)
+}
+
+/// Ensure the binary's directory is in the user's PATH (independent of service registration).
+pub fn ensure_path_entry(exe_path: &Path) -> anyhow::Result<()> {
+    platform::ensure_path_entry(exe_path)
 }
 
 /// Uninstall the system service for the current platform.

--- a/docs/service-registration.md
+++ b/docs/service-registration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-ACS registers itself as a **user-level service** (not system-wide) so the daemon automatically starts at login. On macOS and Linux, this does not require root or administrator privileges. On Windows, the `schtasks /Create` command may require elevated permissions, and the task runs at the highest available privilege level (`/RL HIGHEST`).
+ACS registers itself as a **user-level service** (not system-wide) so the daemon automatically starts at login. On macOS and Linux, this does not require root or administrator privileges. On Windows, registration attempts to use the highest available privilege level (`/RL HIGHEST`), but gracefully degrades to normal privilege level if elevation is unavailable — the task is still registered and will run at login.
 
 Each platform uses its native service manager:
 
@@ -24,17 +24,27 @@ Windows uses **Task Scheduler** (`schtasks.exe`). The task is created for the cu
 
 - **Task name:** `AgentCronScheduler`
 - **Trigger:** `ONLOGON`
-- **Run level:** `HIGHEST`
+- **Run level:** `HIGHEST` (attempted first; falls back to normal privilege if elevation is unavailable)
 
 ### Install (Register)
+
+Registration uses a two-attempt strategy:
+
+1. **First attempt** — tries with `/RL HIGHEST` (elevated run level):
 
 ```
 schtasks /Create /TN AgentCronScheduler /TR "\"<exe_path>\" start" /SC ONLOGON /RL HIGHEST /F
 ```
 
+2. **Fallback attempt** — if the first attempt fails (e.g., the user is not running elevated), retries without `/RL HIGHEST`:
+
+```
+schtasks /Create /TN AgentCronScheduler /TR "\"<exe_path>\" start" /SC ONLOGON /F
+```
+
 The `/F` flag forces creation, overwriting any existing task with the same name. The quotes wrap only the executable path (to handle paths with spaces), not the entire command. The task runs `agentcronsystem start` (not `--foreground`), which means the task itself completes quickly: it spawns the daemon as a hidden background process and exits. The daemon then runs independently.
 
-**Note:** On first install or start, the binary is automatically added to the user's PATH (Windows: User Environment Variable; Unix: shell profile). This allows `agentcronsystem` to be invoked from any directory without specifying the full path.
+**Note:** On every background `start` invocation, the binary is automatically added to the user's PATH if not already present (Windows: User Environment Variable; Unix: shell profile). This PATH registration happens independently of service registration — it occurs regardless of whether `install_service()` succeeds or whether the service was already registered. This allows `agentcronsystem` to be invoked from any directory without specifying the full path.
 
 ### Detect Registration
 

--- a/electron/packages/app/electron/preload.js
+++ b/electron/packages/app/electron/preload.js
@@ -16,7 +16,7 @@ const acsBinaryPath = getArg('agentcronsystem-binary');
 function getDaemonPort() {
   if (!dataDir) return null;
   try {
-    return fs.readFileSync(path.join(dataDir, 'acs.port'), 'utf8').trim() || null;
+    return fs.readFileSync(path.join(dataDir, 'agentcronsystem.port'), 'utf8').trim() || null;
   } catch {
     return null;
   }

--- a/electron/packages/frontend/src/components/CostTrendChart.tsx
+++ b/electron/packages/frontend/src/components/CostTrendChart.tsx
@@ -6,6 +6,11 @@ interface CostTrendChartProps {
 }
 
 export function CostTrendChart({ runs }: CostTrendChartProps) {
+  // Guard against undefined/null or non-array runs
+  if (!runs || !Array.isArray(runs)) {
+    return null;
+  }
+
   // Filter to runs with actual cost data
   const qualifying = runs.filter(
     (r) => r.total_cost_usd != null && r.total_cost_usd > 0

--- a/electron/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/electron/packages/frontend/src/components/layout/Sidebar.tsx
@@ -129,7 +129,9 @@ export function Sidebar() {
   const fetchJobs = useCallback(async () => {
     try {
       const data = await api.listJobs();
-      setJobs(data);
+      if (Array.isArray(data)) {
+        setJobs(data);
+      }
     } catch {
       // Ignore errors silently in sidebar
     }

--- a/electron/packages/frontend/src/hooks/useJobs.ts
+++ b/electron/packages/frontend/src/hooks/useJobs.ts
@@ -12,7 +12,9 @@ export function useJobs() {
   const refresh = useCallback(async () => {
     try {
       const data = await api.listJobs();
-      setJobs(data);
+      if (Array.isArray(data)) {
+        setJobs(data);
+      }
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch jobs");

--- a/electron/packages/frontend/src/hooks/useRuns.ts
+++ b/electron/packages/frontend/src/hooks/useRuns.ts
@@ -14,8 +14,10 @@ export function useRuns(jobId: string, limit: number = 20, offset: number = 0) {
     if (!jobId) return;
     try {
       const data = await api.listRuns(jobId, limit, offset);
-      setRuns(data.runs);
-      setTotal(data.total);
+      if (data && Array.isArray(data.runs)) {
+        setRuns(data.runs);
+        setTotal(data.total);
+      }
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch runs");

--- a/electron/packages/frontend/src/routes/JobDetailPage.tsx
+++ b/electron/packages/frontend/src/routes/JobDetailPage.tsx
@@ -372,7 +372,7 @@ export function JobDetailPage() {
             ({total})
           </span>
         </h2>
-        <CostTrendChart runs={allRuns} />
+        {Array.isArray(allRuns) && <CostTrendChart runs={allRuns} />}
         {runsLoading && allRuns.length === 0 ? (
           <div className="flex items-center justify-center py-6">
             <ArrowPathIcon className="h-6 w-6 animate-spin text-muted-foreground" />


### PR DESCRIPTION
## Summary

Fixes multiple issues discovered on fresh Windows installs via the Electron installer:

- **Preload port file mismatch** — `preload.js` read `acs.port` but daemon writes `agentcronsystem.port`, causing all API calls to hit the Electron static server instead of the daemon
- **Service registration fails silently** — `schtasks /Create /SC ONLOGON` requires elevation; added fallback without `/RL HIGHEST`
- **PATH registration coupled to service registration** — decoupled `ensure_path_entry()` so it runs independently on every background `start`
- **install_service() feedback invisible** — added `tracing` calls alongside `println`/`eprintln` so messages appear in `daemon.log` when spawned from Electron
- **React UI filter crash** — API responses returning `undefined` (due to HTML content-type from static server) caused `.filter()` on undefined; added `Array.isArray()` guards

## Changes

| File | Change |
|------|--------|
| `electron/.../preload.js` | Fix port filename: `acs.port` → `agentcronsystem.port` |
| `acs/src/daemon/service.rs` | Decouple `ensure_path_entry()` from `install_service()`; add Windows elevation fallback |
| `acs/src/cli/daemon.rs` | Call `ensure_path_entry()` independently; add tracing for service registration |
| `electron/.../Sidebar.tsx` | Guard `setJobs()` with `Array.isArray()` |
| `electron/.../useJobs.ts` | Guard `setJobs()` with `Array.isArray()` |
| `electron/.../useRuns.ts` | Guard `setRuns()` with `Array.isArray()` and null check on response |
| `electron/.../CostTrendChart.tsx` | Add null/type guard before `.filter()` |
| `electron/.../JobDetailPage.tsx` | Add `Array.isArray()` guard at `CostTrendChart` call site |
| `docs/service-registration.md` | Update Windows section for elevation fallback and independent PATH |

## Test plan

- [x] All Rust tests pass
- [x] `cargo fmt --check` clean
- [x] Frontend builds successfully
- [x] Verified on Windows: PATH is set after fresh install
- [x] Verified on Windows: Dashboard loads with data
- [x] Verified on Windows: Jobs list, system logs work correctly
- [x] Verified on Windows: No filter TypeError in console

Closes #65