### PR TITLE
Switch Windows auto-start from schtasks to Registry Run key

### DIFF
--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,6 +1,1 @@
-[
-  {
-    "issue": 67,
-    "body": "## Approved Implementation Plan\n\n**Sub-Task A (Standard):** Replace all schtasks functions in Windows `mod platform` block with `winreg` operations against `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run`. Covers: `install_service()`, `uninstall_service()`, `is_service_registered()`, `service_path()`, `start_service()` (error stub), `stop_service()` (error stub). Add constants `RUN_KEY_PATH` and `RUN_VALUE_NAME`. `service_name()`/`platform_name()` unchanged.\n\n**Sub-Task B (Standard):** Add `mod run_key_tests` (6 new tests with isolated temp registry keys). Update existing cross-platform test `test_uninstall_service_when_not_registered` assertion.\n\n**Sub-Task C (Standard):** Rewrite Windows section of `docs/service-registration.md` — replace all schtasks references with registry-based mechanism.\n\n**Execution order:** A → B → C (sequential)\n\n_Plan auto-approved via nightly autonomous run._"
-  }
-]
+[]

--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "issue": 67,
+    "body": "## Approved Implementation Plan\n\n**Sub-Task A (Standard):** Replace all schtasks functions in Windows `mod platform` block with `winreg` operations against `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run`. Covers: `install_service()`, `uninstall_service()`, `is_service_registered()`, `service_path()`, `start_service()` (error stub), `stop_service()` (error stub). Add constants `RUN_KEY_PATH` and `RUN_VALUE_NAME`. `service_name()`/`platform_name()` unchanged.\n\n**Sub-Task B (Standard):** Add `mod run_key_tests` (6 new tests with isolated temp registry keys). Update existing cross-platform test `test_uninstall_service_when_not_registered` assertion.\n\n**Sub-Task C (Standard):** Rewrite Windows section of `docs/service-registration.md` — replace all schtasks references with registry-based mechanism.\n\n**Execution order:** A → B → C (sequential)\n\n_Plan auto-approved via nightly autonomous run._"
+  }
+]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supports Windows, macOS, and Linux.
 - **Cron scheduling** -- standard 5-field cron expressions with timezone support
 - **REST API** -- full CRUD for jobs, paginated run history, real-time SSE streaming
 - **CLI** -- manage jobs, view logs, trigger runs from the terminal
-- **Cross-platform** -- Windows (Task Scheduler), macOS (launchd), Linux (systemd) service integration
+- **Cross-platform** -- Windows (Registry Run key), macOS (launchd), Linux (systemd) service integration
 - **Persistent storage** -- JSON-backed job store with atomic writes and corruption recovery
 - **Run capture** -- stdout/stderr captured and stored per-run with automatic log rotation
 

--- a/acs/Cargo.lock
+++ b/acs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-cron-scheduler"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/acs/src/daemon/service.rs
+++ b/acs/src/daemon/service.rs
@@ -1,6 +1,6 @@
 // Platform service registration for daemon persistence.
 //
-// - Windows: Task Scheduler (runs as current user, inherits user environment)
+// - Windows: Registry Run key (HKCU\Software\Microsoft\Windows\CurrentVersion\Run)
 // - macOS:   launchd plist to ~/Library/LaunchAgents/com.agentcronsystem.scheduler.plist
 // - Linux:   systemd user unit to ~/.config/systemd/user/agentcronsystem.service
 
@@ -40,130 +40,86 @@ pub fn service_name() -> &'static str {
 }
 
 // ---------------------------------------------------------------------------
-// Windows implementation — uses Task Scheduler (runs as the current user,
-// inheriting their full environment: PATH, USERPROFILE, APPDATA, etc.)
+// Windows implementation — uses Registry Run key
+// (HKCU\Software\Microsoft\Windows\CurrentVersion\Run) so the daemon starts
+// automatically at user logon without requiring elevation.
 // ---------------------------------------------------------------------------
 #[cfg(target_os = "windows")]
 mod platform {
     use super::*;
 
-    const TASK_NAME: &str = "AgentCronScheduler";
+    const RUN_KEY_PATH: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+    const RUN_VALUE_NAME: &str = "AgentCronScheduler";
 
-    /// Check if the scheduled task is registered.
+    /// Check if the Run key value is present in the registry.
     pub fn is_service_registered() -> bool {
-        std::process::Command::new("schtasks")
-            .args(["/Query", "/TN", TASK_NAME])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+        use winreg::enums::*;
+        use winreg::RegKey;
+
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        match hkcu.open_subkey_with_flags(RUN_KEY_PATH, KEY_READ) {
+            Ok(key) => key.get_value::<String, _>(RUN_VALUE_NAME).is_ok(),
+            Err(_) => false,
+        }
     }
 
-    /// Create a scheduled task that runs the daemon at user logon.
+    /// Write the Run key value so the daemon launches at user logon.
     pub fn install_service(exe_path: &Path) -> anyhow::Result<()> {
-        use anyhow::Context;
+        use winreg::enums::*;
+        use winreg::RegKey;
 
-        let exe = exe_path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("Invalid executable path"))?;
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let key = hkcu.open_subkey_with_flags(RUN_KEY_PATH, KEY_SET_VALUE)?;
 
-        // The task runs `acs start` (not --foreground) as the current user.
-        // `acs start` spawns the daemon as a hidden background process and exits,
-        // so the task completes quickly while the daemon runs independently.
-        let tr = format!("\"{}\" start", exe);
+        let value = format!("\"{}\" start", exe_path.display());
+        key.set_value(RUN_VALUE_NAME, &value)?;
 
-        // First attempt: with /RL HIGHEST (requires elevation).
-        let status = std::process::Command::new("schtasks")
-            .args([
-                "/Create", "/TN", TASK_NAME, "/TR", &tr, "/SC", "ONLOGON", "/RL", "HIGHEST", "/F",
-            ])
-            .status()
-            .context("Failed to run schtasks")?;
-
-        if status.success() {
-            return Ok(());
-        }
-
-        // Fallback: retry without /RL HIGHEST so non-elevated users can still
-        // register the task (it will run at normal privilege level).
-        tracing::warn!(
-            "schtasks /Create with /RL HIGHEST failed (exit code {:?}), retrying without elevation",
-            status.code()
-        );
-
-        let status_fallback = std::process::Command::new("schtasks")
-            .args([
-                "/Create", "/TN", TASK_NAME, "/TR", &tr, "/SC", "ONLOGON", "/F",
-            ])
-            .status()
-            .context("Failed to run schtasks (fallback)")?;
-
-        if status_fallback.success() {
-            Ok(())
-        } else {
-            anyhow::bail!(
-                "schtasks /Create failed (exit code {:?})",
-                status_fallback.code()
-            )
-        }
+        tracing::info!("Registered auto-start Run key: {}", value);
+        Ok(())
     }
 
-    /// Delete the scheduled task.
+    /// Remove the Run key value. Succeeds even if the value is absent (idempotent).
     pub fn uninstall_service() -> anyhow::Result<()> {
-        use anyhow::Context;
+        use winreg::enums::*;
+        use winreg::RegKey;
 
-        let status = std::process::Command::new("schtasks")
-            .args(["/Delete", "/TN", TASK_NAME, "/F"])
-            .status()
-            .context("Failed to run schtasks")?;
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let key = hkcu.open_subkey_with_flags(RUN_KEY_PATH, KEY_SET_VALUE)?;
 
-        if status.success() {
-            Ok(())
-        } else {
-            anyhow::bail!("schtasks /Delete failed (exit code {:?})", status.code())
+        match key.delete_value(RUN_VALUE_NAME) {
+            Ok(()) => {
+                tracing::info!("Removed auto-start Run key value: {}", RUN_VALUE_NAME);
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(anyhow::anyhow!(e)),
         }
     }
 
-    /// Get a human-readable description of where the task is registered.
+    /// Get a human-readable description of where the Run entry is registered.
     pub fn service_path() -> Option<String> {
         if is_service_registered() {
-            Some(format!("Task Scheduler: {}", TASK_NAME))
+            Some(format!(
+                r"Registry: HKCU\{}\{}",
+                RUN_KEY_PATH, RUN_VALUE_NAME
+            ))
         } else {
             None
         }
     }
 
-    /// Start the scheduled task immediately.
+    /// Not supported with registry-based auto-start.
     pub fn start_service() -> anyhow::Result<()> {
-        use anyhow::Context;
-
-        let status = std::process::Command::new("schtasks")
-            .args(["/Run", "/TN", TASK_NAME])
-            .status()
-            .context("Failed to run schtasks")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            anyhow::bail!("schtasks /Run failed (exit code {:?})", status.code())
-        }
+        Err(anyhow::anyhow!(
+            "start_service is not supported with registry-based auto-start on Windows"
+        ))
     }
 
-    /// End (hard-kill) the scheduled task.
+    /// Not supported with registry-based auto-start.
     pub fn stop_service() -> anyhow::Result<()> {
-        use anyhow::Context;
-
-        let status = std::process::Command::new("schtasks")
-            .args(["/End", "/TN", TASK_NAME])
-            .status()
-            .context("Failed to run schtasks")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            anyhow::bail!("schtasks /End failed (exit code {:?})", status.code())
-        }
+        Err(anyhow::anyhow!(
+            "stop_service is not supported with registry-based auto-start on Windows"
+        ))
     }
 
     /// Ensure the binary's directory is in the user's PATH (HKCU\Environment).

--- a/acs/src/daemon/service.rs
+++ b/acs/src/daemon/service.rs
@@ -912,7 +912,10 @@ mod tests {
                 let stored: String = key
                     .get_value(RUN_VALUE_NAME)
                     .expect("value should still be present");
-                assert_eq!(stored, value, "value should be correct after idempotent write");
+                assert_eq!(
+                    stored, value,
+                    "value should be correct after idempotent write"
+                );
             });
         }
 
@@ -928,10 +931,7 @@ mod tests {
                     .expect("delete should succeed when value exists");
 
                 let check: Result<String, _> = key.get_value(RUN_VALUE_NAME);
-                assert!(
-                    check.is_err(),
-                    "value should be absent after deletion"
-                );
+                assert!(check.is_err(), "value should be absent after deletion");
             });
         }
 
@@ -960,8 +960,7 @@ mod tests {
         fn test_is_registered_true_when_present() {
             with_temp_key("is_registered_true", |key| {
                 let value = format!("\"{}\" start", r"C:\ACS\acs.exe");
-                key.set_value(RUN_VALUE_NAME, &value)
-                    .expect("set value");
+                key.set_value(RUN_VALUE_NAME, &value).expect("set value");
 
                 let registered = key.get_value::<String, _>(RUN_VALUE_NAME).is_ok();
                 assert!(registered, "should report registered when value is present");

--- a/acs/src/daemon/service.rs
+++ b/acs/src/daemon/service.rs
@@ -709,14 +709,23 @@ mod tests {
 
     #[test]
     fn test_uninstall_service_when_not_registered() {
-        // If service is not registered, uninstall should fail gracefully
+        // If service is not registered, uninstall should behave gracefully.
         if !is_service_registered() {
             let result = uninstall_service();
-            // On Windows, this will fail to find the service
-            // On Unix, this will fail because the file doesn't exist
+            // On Windows the registry-based implementation is idempotent —
+            // deleting an absent value returns Ok(()).
+            #[cfg(target_os = "windows")]
             assert!(
-                result.is_err(),
-                "uninstall_service should fail when service is not registered"
+                result.is_ok(),
+                "uninstall_service should succeed (idempotent) when not registered on Windows"
+            );
+            // On macOS / Linux the plist / unit file simply doesn't exist,
+            // so the function returns Ok(()) as well (early return when path missing).
+            #[cfg(not(target_os = "windows"))]
+            assert!(
+                result.is_ok(),
+                "uninstall_service should return Ok(()) when not registered: {:?}",
+                result
             );
         }
     }

--- a/acs/src/daemon/service.rs
+++ b/acs/src/daemon/service.rs
@@ -847,4 +847,137 @@ mod tests {
             let _ = result;
         }
     }
+
+    /// Tests for the Windows Registry Run key logic used by install_service /
+    /// uninstall_service / is_service_registered. All tests operate on unique
+    /// temporary keys under `HKCU\Software\AcsRunTest_*` and never touch the
+    /// real `HKCU\...\Run` key.
+    #[cfg(target_os = "windows")]
+    mod run_key_tests {
+        use winreg::enums::*;
+        use winreg::RegKey;
+
+        const RUN_VALUE_NAME: &str = "AgentCronScheduler";
+
+        /// Create a uniquely-named temp key, execute the closure, then delete
+        /// the entire temp key tree. Returns whatever the closure returned.
+        fn with_temp_key<F, T>(test_name: &str, f: F) -> T
+        where
+            F: FnOnce(&RegKey) -> T,
+        {
+            let subkey = format!("Software\\AcsRunTest_{}", test_name);
+            let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+            let (key, _) = hkcu.create_subkey(&subkey).expect("create temp run key");
+            let result = f(&key);
+            drop(key);
+            hkcu.delete_subkey_all(&subkey).ok();
+            result
+        }
+
+        /// Simulate the install_service write — sets `"<path>" start` — then
+        /// reads the value back and verifies the format.
+        #[test]
+        fn test_install_writes_run_value() {
+            with_temp_key("install_writes", |key| {
+                let exe_path = r"C:\Program Files\ACS\acs.exe";
+                let expected = format!("\"{}\" start", exe_path);
+
+                key.set_value(RUN_VALUE_NAME, &expected)
+                    .expect("set run value");
+
+                let stored: String = key
+                    .get_value(RUN_VALUE_NAME)
+                    .expect("value should be present after write");
+
+                assert_eq!(
+                    stored, expected,
+                    "stored value should match \"<path>\" start format"
+                );
+            });
+        }
+
+        /// Writing the value twice (simulating repeated install) should leave
+        /// the correct final value without error.
+        #[test]
+        fn test_install_is_idempotent() {
+            with_temp_key("install_idempotent", |key| {
+                let exe_path = r"C:\Tools\acs.exe";
+                let value = format!("\"{}\" start", exe_path);
+
+                key.set_value(RUN_VALUE_NAME, &value)
+                    .expect("first write should succeed");
+                key.set_value(RUN_VALUE_NAME, &value)
+                    .expect("second write should also succeed");
+
+                let stored: String = key
+                    .get_value(RUN_VALUE_NAME)
+                    .expect("value should still be present");
+                assert_eq!(stored, value, "value should be correct after idempotent write");
+            });
+        }
+
+        /// Writing then deleting a value should leave it absent.
+        #[test]
+        fn test_uninstall_removes_value() {
+            with_temp_key("uninstall_removes", |key| {
+                let value = format!("\"{}\" start", r"C:\Tools\acs.exe");
+                key.set_value(RUN_VALUE_NAME, &value)
+                    .expect("set value before uninstall");
+
+                key.delete_value(RUN_VALUE_NAME)
+                    .expect("delete should succeed when value exists");
+
+                let check: Result<String, _> = key.get_value(RUN_VALUE_NAME);
+                assert!(
+                    check.is_err(),
+                    "value should be absent after deletion"
+                );
+            });
+        }
+
+        /// Attempting to delete a value that does not exist should return
+        /// Ok(()) (idempotent), mirroring the production uninstall_service logic.
+        #[test]
+        fn test_uninstall_when_absent() {
+            with_temp_key("uninstall_absent", |key| {
+                // Value has never been set — mirror the production logic.
+                let result: anyhow::Result<()> = match key.delete_value(RUN_VALUE_NAME) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(anyhow::anyhow!("Failed to remove registry value: {}", e)),
+                };
+
+                assert!(
+                    result.is_ok(),
+                    "uninstall on absent value should be idempotent (Ok): {:?}",
+                    result
+                );
+            });
+        }
+
+        /// A value that is present should be detected as registered.
+        #[test]
+        fn test_is_registered_true_when_present() {
+            with_temp_key("is_registered_true", |key| {
+                let value = format!("\"{}\" start", r"C:\ACS\acs.exe");
+                key.set_value(RUN_VALUE_NAME, &value)
+                    .expect("set value");
+
+                let registered = key.get_value::<String, _>(RUN_VALUE_NAME).is_ok();
+                assert!(registered, "should report registered when value is present");
+            });
+        }
+
+        /// A value that has never been written should be detected as absent.
+        #[test]
+        fn test_is_registered_false_when_absent() {
+            with_temp_key("is_registered_false", |key| {
+                let registered = key.get_value::<String, _>(RUN_VALUE_NAME).is_ok();
+                assert!(
+                    !registered,
+                    "should report not-registered when value is absent"
+                );
+            });
+        }
+    }
 }

--- a/acs/src/daemon/service.rs
+++ b/acs/src/daemon/service.rs
@@ -91,7 +91,9 @@ mod platform {
                 tracing::info!("Removed auto-start Run key value: {}", RUN_VALUE_NAME);
                 Ok(())
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound || e.raw_os_error() == Some(2) => {
+                Ok(())
+            }
             Err(e) => Err(anyhow::anyhow!(e)),
         }
     }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,7 +11,7 @@ Documentation for the Agent Cron Scheduler (ACS) -- a cross-platform cron schedu
 | [CLI Reference](cli-reference.md) | All `agentcronsystem` subcommands: flags, options, exit codes, usage examples. |
 | [API Reference](api-reference.md) | REST API endpoints: routes, request/response formats, status codes, SSE events, data models. |
 | [Job Management](job-management.md) | Job model, execution types, cron expressions, timezone support, job lifecycle, validation rules. |
-| [Service Registration](service-registration.md) | Platform-specific service setup: Windows Task Scheduler, macOS launchd, Linux systemd. |
+| [Service Registration](service-registration.md) | Platform-specific service setup: Windows Registry Run key, macOS launchd, Linux systemd. |
 | [Storage](storage.md) | On-disk persistence: JsonJobStore, FsLogStore, file formats, log rotation, daemon log management, storage traits. |
 | [Troubleshooting](troubleshooting.md) | Common problems and solutions: startup issues, job execution, logs, data corruption, CLI errors. |
 | [Known Issues](KNOWN_ISSUES.md) | Remaining documentation issues identified during Round 3 audits; minor items that do not affect core accuracy. |

--- a/docs/service-registration.md
+++ b/docs/service-registration.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-ACS registers itself as a **user-level service** (not system-wide) so the daemon automatically starts at login. On macOS and Linux, this does not require root or administrator privileges. On Windows, registration attempts to use the highest available privilege level (`/RL HIGHEST`), but gracefully degrades to normal privilege level if elevation is unavailable — the task is still registered and will run at login.
+ACS registers itself as a **user-level service** (not system-wide) so the daemon automatically starts at login. On all supported platforms this does not require root or administrator privileges — Windows uses a HKCU registry write, which requires no elevation.
 
 Each platform uses its native service manager:
 
-| Platform | Service Manager      | Service Name                       |
-|----------|----------------------|------------------------------------|
-| Windows  | Task Scheduler       | `AgentCronScheduler`               |
-| macOS    | launchd              | `com.agentcronsystem.scheduler`    |
-| Linux    | systemd (user units) | `agentcronsystem`                  |
+| Platform | Service Manager        | Service Name                       |
+|----------|------------------------|------------------------------------|
+| Windows  | Registry Run key       | `AgentCronScheduler`               |
+| macOS    | launchd                | `com.agentcronsystem.scheduler`    |
+| Linux    | systemd (user units)   | `agentcronsystem`                  |
 
 The cross-platform API is exposed through `acs/src/daemon/service.rs`, which delegates to a platform-specific `mod platform` block selected at compile time via `#[cfg(target_os = "...")]`.
 
@@ -20,61 +20,50 @@ The cross-platform API is exposed through `acs/src/daemon/service.rs`, which del
 
 ### Service Manager
 
-Windows uses **Task Scheduler** (`schtasks.exe`). The task is created for the current user and runs at logon.
+Windows uses the **Registry Run key** (`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`). A `REG_SZ` value is created under that key so the daemon launches automatically at user logon. No elevation is required — writes to `HKCU` are always permitted for the current user.
 
-- **Task name:** `AgentCronScheduler`
-- **Trigger:** `ONLOGON`
-- **Run level:** `HIGHEST` (attempted first; falls back to normal privilege if elevation is unavailable)
+- **Value name:** `AgentCronScheduler`
+- **Value data:** `"<exe_path>" start`
+- **Trigger:** user logon (Windows reads all `Run` key values at logon)
 
 ### Install (Register)
 
-Registration uses a two-attempt strategy:
-
-1. **First attempt** — tries with `/RL HIGHEST` (elevated run level):
+Registration is a single registry write:
 
 ```
-schtasks /Create /TN AgentCronScheduler /TR "\"<exe_path>\" start" /SC ONLOGON /RL HIGHEST /F
+HKCU\Software\Microsoft\Windows\CurrentVersion\Run
+  AgentCronScheduler = "<exe_path>" start
 ```
 
-2. **Fallback attempt** — if the first attempt fails (e.g., the user is not running elevated), retries without `/RL HIGHEST`:
-
-```
-schtasks /Create /TN AgentCronScheduler /TR "\"<exe_path>\" start" /SC ONLOGON /F
-```
-
-The `/F` flag forces creation, overwriting any existing task with the same name. The quotes wrap only the executable path (to handle paths with spaces), not the entire command. The task runs `agentcronsystem start` (not `--foreground`), which means the task itself completes quickly: it spawns the daemon as a hidden background process and exits. The daemon then runs independently.
+The value data quotes only the executable path (to handle paths with spaces) and appends the `start` sub-command. Writing the value when one already exists silently overwrites it, so the operation is idempotent.
 
 **Note:** On every background `start` invocation, the binary is automatically added to the user's PATH if not already present (Windows: User Environment Variable; Unix: shell profile). This PATH registration happens independently of service registration — it occurs regardless of whether `install_service()` succeeds or whether the service was already registered. This allows `agentcronsystem` to be invoked from any directory without specifying the full path.
 
 ### Detect Registration
 
-```
-schtasks /Query /TN AgentCronScheduler
-```
+Registration is detected by checking whether the `AgentCronScheduler` value is present under the Run key:
 
-A successful exit code means the task exists; a non-zero exit code means it does not.
+```rust
+fn is_service_registered() -> bool {
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    match hkcu.open_subkey_with_flags(RUN_KEY_PATH, KEY_READ) {
+        Ok(key) => key.get_value::<String, _>(RUN_VALUE_NAME).is_ok(),
+        Err(_) => false,
+    }
+}
+```
 
 ### Start
 
-> **Note:** On Windows, `agentcronsystem start` in background mode does **not** use `schtasks /Run`. Instead, it spawns `agentcronsystem start --foreground` directly as a hidden process via `Command::new()`. The `start_service()` function (which wraps `schtasks /Run`) is compiled on Windows but is unreachable: `cmd_start` calls `start_service()` only inside a `#[cfg(not(target_os = "windows"))]` block (`daemon.rs`), so no CLI code path invokes it on Windows.
+> **Note:** `start_service()` is not applicable for registry-based auto-start. On Windows, `acs start` spawns the daemon directly as a hidden background process via `Command::new()`. The Run key entry only causes Windows to launch the daemon automatically at the next logon — it is not used to start the daemon on demand.
 
-### Stop (Service Fallback)
+### Stop
 
-In practice, `agentcronsystem stop` first attempts a graceful shutdown via the HTTP API (`POST /api/shutdown`). The `schtasks /End` command is only used as a fallback when the API is unreachable and the service is registered:
-
-```
-schtasks /End /TN AgentCronScheduler
-```
-
-Terminates the running task instance.
-
-Additionally, `agentcronsystem stop --force` bypasses both mechanisms and reads the PID file to force-kill the daemon via `taskkill /F /PID <pid>`.
+> **Note:** `stop_service()` is not applicable for registry-based auto-start. `acs stop` first attempts a graceful shutdown via the HTTP API (`POST /api/shutdown`). If the API is unreachable, it falls back to a PID-based kill via `taskkill /F /PID <pid>`.
 
 ### Uninstall (Unregister)
 
-```
-schtasks /Delete /TN AgentCronScheduler /F
-```
+Uninstallation deletes the `AgentCronScheduler` value from the Run key. The operation is idempotent — if the value is already absent, `uninstall_service()` returns `Ok(())` without error.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,15 +71,15 @@ ACS searches for configuration in a 5-level priority order. See [Configuration](
 
 ACS registers itself as a user-level service for auto-start at login. See [Service Registration](service-registration.md) for full platform-specific details (service names, file locations, install/uninstall commands).
 
-### Windows (Task Scheduler)
+### Windows (Registry Run Key)
 
 **Symptom:** `Warning: Could not register auto-start` when running `agentcronsystem start`.
 
 **Possible causes:**
-- Insufficient permissions. Try running your terminal as Administrator.
-- The `schtasks` command is not available or is blocked by group policy.
+- Registry write failed. Check that `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` is writable.
+- Antivirus or group policy blocking registry writes to the Run key.
 
-**Quick check:** `schtasks /Query /TN AgentCronScheduler`
+**Quick check:** `reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" /v AgentCronScheduler`
 
 ### macOS (launchd)
 


### PR DESCRIPTION
## Summary
- Replace all Windows Task Scheduler (`schtasks`) usage with Registry Run key (`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`) for auto-start registration
- The Registry Run key approach requires no elevation and does not silently fail on non-elevated installs
- Closes #67

## Changes
| File | Change |
|------|--------|
| `acs/src/daemon/service.rs` | Rewrote Windows `mod platform`: replaced schtasks calls with `winreg` registry operations for install, uninstall, and detection. `start_service`/`stop_service` return errors (no registry equivalent). Added `RUN_KEY_PATH` and `RUN_VALUE_NAME` constants. Added 6 new registry tests (`run_key_tests`). Fixed `test_uninstall_service_when_not_registered` assertion. |
| `docs/service-registration.md` | Rewrote Windows section: Registry Run key mechanism, no elevation, idempotent uninstall |
| `docs/troubleshooting.md` | Updated Windows troubleshooting: registry-relevant causes and diagnostic command |
| `docs/INDEX.md` | Updated description: "Windows Registry Run key" |
| `README.md` | Updated feature bullet: "Windows (Registry Run key)" |

## AI Suggested Testing Plan
- [ ] On Windows: run `acs start` and verify the Registry Run key is created at `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\AgentCronScheduler`
- [ ] Verify `acs status` shows registered with registry path
- [ ] Verify `acs stop && acs uninstall` removes the registry value
- [ ] Verify re-running `acs start` is idempotent (no error on re-registration)
- [ ] Run `cargo test` on Windows to verify all service tests pass (including 6 new registry tests)
- [ ] Verify macOS and Linux behavior is completely unchanged

## Ticket
#67 — https://github.com/jgardner04/agent-cron-scheduler/issues/67

---
Generated by the starterpack orchestrator.