### PR TITLE
Per-job manifest file system with cost & token tracking (#71)

### DIFF
--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,6 +1,1 @@
-[
-  {
-    "issue": 71,
-    "body": "## Approved Implementation Plan\n\n### Sub-tasks\n\n| # | Description | Complexity | Dependencies |\n|---|------------|------------|-------------|\n| 1 | Define `JobManifest` model structs + `merge_run` method | Standard | None |\n| 2 | Add manifest methods to `LogStore` trait + `FsLogStore` impl | Complex | 1 |\n| 3 | Call `update_manifest` after run completion in executor | Light | 2 |\n| 4 | Unit tests for aggregation, bucketing, serialization | Standard | 1 |\n| 5 | Integration tests for FsLogStore manifest operations | Standard | 1, 2 |\n\n### Execution Order\n- Phase 1: Sub-task 1\n- Phase 2 (parallel): Sub-tasks 2, 4\n- Phase 3 (parallel): Sub-tasks 3, 5\n\n### Key Design Decisions\n- Per-model: Use `run.model` as single model key per run (pragmatic, matches current data fidelity)\n- Cleanup ordering: `update_manifest` called BEFORE `cleanup` at convergence point\n- Weekly/monthly buckets: Independently maintained in `merge_run`\n- Windows atomic write: Remove target before rename\n- Executor: Single `update_manifest` call at convergence point, not per-branch\n\n🤖 Plan auto-approved (autonomous nightly run)"
-  }
-]
+[]

--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "issue": 71,
+    "body": "## Approved Implementation Plan\n\n### Sub-tasks\n\n| # | Description | Complexity | Dependencies |\n|---|------------|------------|-------------|\n| 1 | Define `JobManifest` model structs + `merge_run` method | Standard | None |\n| 2 | Add manifest methods to `LogStore` trait + `FsLogStore` impl | Complex | 1 |\n| 3 | Call `update_manifest` after run completion in executor | Light | 2 |\n| 4 | Unit tests for aggregation, bucketing, serialization | Standard | 1 |\n| 5 | Integration tests for FsLogStore manifest operations | Standard | 1, 2 |\n\n### Execution Order\n- Phase 1: Sub-task 1\n- Phase 2 (parallel): Sub-tasks 2, 4\n- Phase 3 (parallel): Sub-tasks 3, 5\n\n### Key Design Decisions\n- Per-model: Use `run.model` as single model key per run (pragmatic, matches current data fidelity)\n- Cleanup ordering: `update_manifest` called BEFORE `cleanup` at convergence point\n- Weekly/monthly buckets: Independently maintained in `merge_run`\n- Windows atomic write: Remove target before rename\n- Executor: Single `update_manifest` call at convergence point, not per-branch\n\n🤖 Plan auto-approved (autonomous nightly run)"
+  }
+]

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -463,6 +463,9 @@ impl Executor {
                         if let Err(e) = log_store.update_run(&failed_run).await {
                             tracing::error!("Failed to save run on pre-hook failure: {}", e);
                         }
+                        if let Err(e) = log_store.update_manifest(job_id, &failed_run).await {
+                            tracing::warn!("Failed to update manifest for job {}: {}", job_id, e);
+                        }
                         let _ = event_tx.send(JobEvent::Completed {
                             job_id,
                             run_id,
@@ -518,6 +521,9 @@ impl Executor {
                     };
                     if let Err(e) = log_store.update_run(&failed_run).await {
                         tracing::error!("Failed to update run on spawn failure: {}", e);
+                    }
+                    if let Err(e) = log_store.update_manifest(job_id, &failed_run).await {
+                        tracing::warn!("Failed to update manifest for job {}: {}", job_id, e);
                     }
 
                     // Cleanup old log files
@@ -741,6 +747,9 @@ impl Executor {
                 if let Err(e) = log_store.update_run(&timeout_run).await {
                     tracing::error!("Failed to update run on timeout: {}", e);
                 }
+                if let Err(e) = log_store.update_manifest(job_id, &timeout_run).await {
+                    tracing::warn!("Failed to update manifest for job {}: {}", job_id, e);
+                }
                 let _ = event_tx.send(JobEvent::Failed {
                     job_id,
                     run_id,
@@ -775,6 +784,9 @@ impl Executor {
                 };
                 if let Err(e) = log_store.update_run(&killed_run).await {
                     tracing::error!("Failed to update run on kill: {}", e);
+                }
+                if let Err(e) = log_store.update_manifest(job_id, &killed_run).await {
+                    tracing::warn!("Failed to update manifest for job {}: {}", job_id, e);
                 }
                 let _ = event_tx.send(JobEvent::Failed {
                     job_id,
@@ -878,6 +890,9 @@ impl Executor {
                     if let Err(e) = log_store.update_run(&completed_run).await {
                         tracing::error!("Failed to update run on completion: {}", e);
                     }
+                    if let Err(e) = log_store.update_manifest(job_id, &completed_run).await {
+                        tracing::warn!("Failed to update manifest for job {}: {}", job_id, e);
+                    }
 
                     let _ = event_tx.send(JobEvent::Completed {
                         job_id,
@@ -908,6 +923,9 @@ impl Executor {
                     if let Err(e) = log_store.update_run(&failed_run).await {
                         tracing::error!("Failed to update run on wait failure: {}", e);
                     }
+                    if let Err(e) = log_store.update_manifest(job_id, &failed_run).await {
+                        tracing::warn!("Failed to update manifest for job {}: {}", job_id, e);
+                    }
 
                     let _ = event_tx.send(JobEvent::Failed {
                         job_id,
@@ -937,6 +955,9 @@ impl Executor {
                     };
                     if let Err(e) = log_store.update_run(&failed_run).await {
                         tracing::error!("Failed to update run on join error: {}", e);
+                    }
+                    if let Err(e) = log_store.update_manifest(job_id, &failed_run).await {
+                        tracing::warn!("Failed to update manifest for job {}: {}", job_id, e);
                     }
 
                     let _ = event_tx.send(JobEvent::Failed {

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -1048,6 +1048,28 @@ mod tests {
             self.cleanup_calls.write().await.push((job_id, max_files));
             Ok(())
         }
+
+        async fn read_manifest(
+            &self,
+            _job_id: Uuid,
+        ) -> anyhow::Result<Option<crate::models::JobManifest>> {
+            Ok(None)
+        }
+
+        async fn update_manifest(
+            &self,
+            _job_id: Uuid,
+            _run: &JobRun,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn rebuild_manifest(
+            &self,
+            _job_id: Uuid,
+        ) -> anyhow::Result<crate::models::JobManifest> {
+            Ok(crate::models::JobManifest::new(_job_id))
+        }
     }
 
     // --- Test helpers ---

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -14,8 +14,8 @@ use crate::storage::LogStore;
 
 /// Result of executing a hook command.
 enum HookOutcome {
-    /// Hook succeeded (exit code zero).
-    Success,
+    /// Hook succeeded (exit code zero) with captured stdout.
+    Success(Vec<u8>),
     /// Hook failed: carries a human-readable description of the failure.
     Failure(String),
 }
@@ -77,7 +77,7 @@ async fn run_hook(
     match tokio::time::timeout(std::time::Duration::from_secs(30), child.wait_with_output()).await {
         Ok(Ok(output)) => {
             if output.status.success() {
-                HookOutcome::Success
+                HookOutcome::Success(output.stdout)
             } else {
                 let code = output.status.code().unwrap_or(-1);
                 let stderr = String::from_utf8_lossy(&output.stderr);
@@ -95,6 +95,9 @@ async fn run_hook(
 }
 
 /// Extracted cost/usage summary from a Claude CLI NDJSON log.
+///
+/// All fields represent aggregates summed across all Claude CLI invocations in the log,
+/// not a single invocation.
 struct CostSummary {
     total_cost_usd: Option<f64>,
     duration_ms: Option<u64>,
@@ -106,11 +109,21 @@ struct CostSummary {
 /// Extract cost data from a Claude CLI NDJSON log.
 ///
 /// Claude CLI emits newline-delimited JSON events. The relevant events are:
-/// - `{"type":"system","subtype":"init",...,"model":"<model>"}` — always near the start
-/// - `{"type":"result",...,"total_cost_usd":...}` — always the last line
+/// - `{"type":"system","subtype":"init",...,"model":"<model>"}` — emitted at session start
+/// - `{"type":"result",...,"total_cost_usd":...}` — emitted at session end
 ///
-/// For performance, only the first 4 KB and last 8 KB of the log are scanned.
-/// Non-NDJSON content (plain shell output, etc.) results in all fields being `None`.
+/// The entire log content is scanned in a single pass to support jobs with multiple Claude invocations.
+///
+/// Aggregation behavior:
+/// - `total_cost_usd`, `duration_ms`, and `num_turns` are summed across all `"type":"result"` events.
+/// - `usage` token fields are merged (summed) across all invocations.
+/// - `model` is set to the first model found from `"type":"system"` events.
+///
+/// Known limitation: If different models are used across invocations in the same log, only the
+/// first model encountered is reported.
+///
+/// Non-NDJSON lines are silently skipped. As a performance optimisation, `serde_json::from_str`
+/// is only called on lines that contain the substring `"type"`.
 fn extract_cost_from_log(log_content: &[u8]) -> CostSummary {
     let mut summary = CostSummary {
         total_cost_usd: None,
@@ -124,49 +137,65 @@ fn extract_cost_from_log(log_content: &[u8]) -> CostSummary {
         return summary;
     }
 
-    // Scan the first ~4KB for the system event (model info is at the start)
-    let head_window = &log_content[..log_content.len().min(4096)];
-    let head_str = String::from_utf8_lossy(head_window);
-    for line in head_str.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-            if val.get("type").and_then(|t| t.as_str()) == Some("system") {
-                if let Some(model) = val.get("model").and_then(|m| m.as_str()) {
-                    summary.model = Some(model.to_string());
-                }
-                break;
-            }
-        }
-    }
+    let content_str = String::from_utf8_lossy(log_content);
 
-    // Scan the last ~8KB for the result event (always the final NDJSON line)
-    let tail_start = log_content.len().saturating_sub(8192);
-    let tail_window = &log_content[tail_start..];
-    let tail_str = String::from_utf8_lossy(tail_window);
-    for line in tail_str.lines() {
+    for line in content_str.lines() {
         let line = line.trim();
-        if line.is_empty() {
+        if line.is_empty() || !line.contains("\"type\"") {
             continue;
         }
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-            if val.get("type").and_then(|t| t.as_str()) == Some("result") {
+
+        let val = match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        match val.get("type").and_then(|t| t.as_str()) {
+            Some("system") => {
+                // Keep the first model seen; continue scanning for result events.
+                if summary.model.is_none() {
+                    if let Some(model) = val.get("model").and_then(|m| m.as_str()) {
+                        summary.model = Some(model.to_string());
+                    }
+                }
+            }
+            Some("result") => {
                 if let Some(cost) = val.get("total_cost_usd").and_then(|v| v.as_f64()) {
-                    summary.total_cost_usd = Some(cost);
+                    *summary.total_cost_usd.get_or_insert(0.0) += cost;
                 }
                 if let Some(ms) = val.get("duration_ms").and_then(|v| v.as_u64()) {
-                    summary.duration_ms = Some(ms);
+                    *summary.duration_ms.get_or_insert(0) += ms;
                 }
                 if let Some(turns) = val.get("num_turns").and_then(|v| v.as_u64()) {
-                    summary.num_turns = Some(turns as u32);
+                    *summary.num_turns.get_or_insert(0) += turns as u32;
                 }
-                if let Some(usage) = val.get("usage").cloned() {
-                    summary.usage = Some(usage);
+                if let Some(serde_json::Value::Object(new_usage)) = val.get("usage").cloned() {
+                    let merged = summary
+                        .usage
+                        .get_or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+                    if let serde_json::Value::Object(ref mut acc) = merged {
+                        for (k, v) in new_usage {
+                            if let Some(n) = v.as_f64() {
+                                let entry = acc.entry(k).or_insert(serde_json::Value::Number(
+                                    serde_json::Number::from(0u64),
+                                ));
+                                let existing = entry.as_f64().unwrap_or(0.0);
+                                // Preserve integer representation where possible.
+                                let sum = existing + n;
+                                *entry = if sum.fract() == 0.0 && sum >= 0.0 {
+                                    serde_json::Value::Number(serde_json::Number::from(sum as u64))
+                                } else {
+                                    serde_json::Value::Number(
+                                        serde_json::Number::from_f64(sum)
+                                            .unwrap_or(serde_json::Number::from(0u64)),
+                                    )
+                                };
+                            }
+                        }
+                    }
                 }
-                break;
             }
+            _ => {}
         }
     }
 
@@ -388,6 +417,10 @@ impl Executor {
 
         // Spawn the execution task
         let join_handle = tokio::spawn(async move {
+            // Track bytes written by hooks (outside the PTY log writer) so they
+            // can be added to total_bytes after the log writer finishes.
+            let mut pre_hook_stdout_len: u64 = 0;
+
             // Run pre-hook if configured (before PTY spawn)
             if let Some(ref hook_cmd) = effective_pre_hook {
                 tracing::debug!("Running pre-hook for job {}: {}", job_id, hook_cmd);
@@ -400,8 +433,12 @@ impl Executor {
                 )
                 .await
                 {
-                    HookOutcome::Success => {
+                    HookOutcome::Success(stdout) => {
                         tracing::debug!("Pre-hook succeeded for job {}", job_id);
+                        if !stdout.is_empty() {
+                            pre_hook_stdout_len = stdout.len() as u64;
+                            log_store.append_log(job_id, run_id, &stdout).await.ok();
+                        }
                     }
                     HookOutcome::Failure(detail) => {
                         let error_msg = format!("Pre-hook failed: {}", detail);
@@ -659,7 +696,9 @@ impl Executor {
             let exit_result = read_handle.await;
 
             // Wait for log writer to finish and get total bytes
-            let total_bytes: u64 = (log_writer_handle.await).unwrap_or_default();
+            let mut total_bytes: u64 = (log_writer_handle.await).unwrap_or_default();
+            // Include bytes written directly by the pre-hook (outside the log writer)
+            total_bytes += pre_hook_stdout_len;
 
             let finished_at = Utc::now();
 
@@ -758,6 +797,7 @@ impl Executor {
                     let exit_code = status.code().unwrap_or(-1);
 
                     // Run post-hook if configured
+                    let mut post_hook_stdout_len: u64 = 0;
                     let (final_status, hook_error) = if let Some(ref hook_cmd) = effective_post_hook
                     {
                         tracing::debug!("Running post-hook for job {}: {}", job_id, hook_cmd);
@@ -771,8 +811,12 @@ impl Executor {
                         )
                         .await
                         {
-                            HookOutcome::Success => {
+                            HookOutcome::Success(stdout) => {
                                 tracing::debug!("Post-hook succeeded for job {}", job_id);
+                                if !stdout.is_empty() {
+                                    post_hook_stdout_len = stdout.len() as u64;
+                                    log_store.append_log(job_id, run_id, &stdout).await.ok();
+                                }
                                 (RunStatus::Completed, None)
                             }
                             HookOutcome::Failure(detail) => {
@@ -784,6 +828,34 @@ impl Executor {
                     } else {
                         (RunStatus::Completed, None)
                     };
+
+                    // Add post-hook stdout bytes to total log size
+                    total_bytes += post_hook_stdout_len;
+
+                    // Re-extract cost to include any hook costs appended to the log
+                    let (cost_total_usd, cost_duration_ms, cost_num_turns, cost_model, cost_usage) =
+                        if post_hook_stdout_len > 0 {
+                            let raw = log_store
+                                .read_log(job_id, run_id, None)
+                                .await
+                                .unwrap_or_default();
+                            let c = extract_cost_from_log(raw.as_bytes());
+                            (
+                                c.total_cost_usd,
+                                c.duration_ms,
+                                c.num_turns,
+                                c.model,
+                                c.usage,
+                            )
+                        } else {
+                            (
+                                cost_total_usd,
+                                cost_duration_ms,
+                                cost_num_turns,
+                                cost_model,
+                                cost_usage,
+                            )
+                        };
 
                     // Per SPEC: non-zero exit is Completed (not Failed).
                     // Failed = infrastructure error only.
@@ -2779,11 +2851,11 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_cost_large_log_uses_tail_window() {
-        // Build a log that is larger than 8KB, with the result event at the very end
+    fn test_extract_cost_large_log_full_scan() {
+        // Build a log larger than 8KB with filler between system and result events to
+        // verify that the full-scan approach finds both regardless of their position.
         let system_line = r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#
             .to_string() + "\n";
-        // Fill with non-NDJSON lines to push the result event past the 8KB head/tail boundary
         let filler: String = (0..500)
             .map(|i| format!("plain output line {}\n", i))
             .collect();
@@ -2792,7 +2864,7 @@ mod tests {
         let log = format!("{}{}{}", system_line, filler, result_line);
         let bytes = log.as_bytes();
 
-        // Confirm log is indeed larger than 8KB
+        // Confirm log is indeed larger than 8KB so this is a meaningful regression guard.
         assert!(
             bytes.len() > 8192,
             "Log should be > 8KB for this test, got {} bytes",
@@ -2803,7 +2875,387 @@ mod tests {
         assert_eq!(summary.total_cost_usd, Some(1.23));
         assert_eq!(summary.duration_ms, Some(99999));
         assert_eq!(summary.num_turns, Some(7));
-        // model is in the first 4KB (system line is small) so it should be found
         assert_eq!(summary.model.as_deref(), Some("claude-sonnet-4-20250514"));
+    }
+
+    #[test]
+    fn test_extract_cost_two_sequential_invocations() {
+        // Two complete Claude NDJSON blocks back-to-back in the same log.
+        let log = concat!(
+            // First invocation
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First"}]}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"total_cost_usd":0.05,"duration_ms":1000,"num_turns":3,"usage":{"input_tokens":100,"output_tokens":50}}"#,
+            "\n",
+            // Second invocation
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second"}]}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"total_cost_usd":0.08,"duration_ms":2000,"num_turns":5,"usage":{"input_tokens":200,"output_tokens":80}}"#,
+            "\n"
+        );
+        let summary = extract_cost_from_log(log.as_bytes());
+
+        // Costs should be summed across both invocations.
+        assert!(
+            (summary.total_cost_usd.unwrap() - 0.13).abs() < 1e-10,
+            "expected total_cost_usd ~0.13, got {:?}",
+            summary.total_cost_usd
+        );
+        assert_eq!(summary.duration_ms, Some(3000));
+        assert_eq!(summary.num_turns, Some(8));
+        // Model comes from the first system event.
+        assert_eq!(summary.model.as_deref(), Some("claude-sonnet-4-20250514"));
+
+        let usage = summary.usage.expect("usage should be Some");
+        assert_eq!(usage["input_tokens"], 300);
+        assert_eq!(usage["output_tokens"], 130);
+    }
+
+    #[test]
+    fn test_extract_cost_mixed_shell_and_claude_output() {
+        // Shell output lines surrounding two Claude NDJSON blocks.
+        let log = concat!(
+            "Starting backup...\n",
+            "Connecting to remote host...\n",
+            // First Claude block
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"result","total_cost_usd":0.03,"duration_ms":500,"num_turns":2,"usage":{"input_tokens":60,"output_tokens":20}}"#,
+            "\n",
+            "Backup complete.\n",
+            "Verifying checksums...\n",
+            // Second Claude block
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"result","total_cost_usd":0.07,"duration_ms":1500,"num_turns":4,"usage":{"input_tokens":140,"output_tokens":60}}"#,
+            "\n",
+            "All done.\n"
+        );
+        let summary = extract_cost_from_log(log.as_bytes());
+
+        // Shell output lines must be silently ignored; costs from both Claude blocks summed.
+        assert!(
+            (summary.total_cost_usd.unwrap() - 0.10).abs() < 1e-10,
+            "expected total_cost_usd ~0.10, got {:?}",
+            summary.total_cost_usd
+        );
+        assert_eq!(summary.duration_ms, Some(2000));
+        assert_eq!(summary.num_turns, Some(6));
+
+        let usage = summary.usage.expect("usage should be Some");
+        assert_eq!(usage["input_tokens"], 200);
+        assert_eq!(usage["output_tokens"], 80);
+    }
+
+    #[test]
+    fn test_extract_cost_large_env_dump_before_system_event() {
+        // Simulate a 6KB+ environment variable dump that precedes the Claude NDJSON block.
+        // This was the old head-window bug: the system event was beyond the first ~4KB window
+        // so the model was never extracted. The full-scan approach must handle it correctly.
+        let env_dump: String = (0..200)
+            .map(|i| format!("ENV_VAR_NUMBER_{}=some_value_that_is_quite_long_{}\n", i, i))
+            .collect();
+        let claude_block = concat!(
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"result","total_cost_usd":0.05,"duration_ms":2000,"num_turns":2,"usage":{"input_tokens":100,"output_tokens":40}}"#,
+            "\n"
+        );
+
+        let log = format!("{}{}", env_dump, claude_block);
+        let bytes = log.as_bytes();
+
+        // Confirm the env dump is genuinely large enough to trigger the old bug.
+        assert!(
+            bytes.len() > 6144,
+            "env dump should be > 6KB for this test, got {} bytes",
+            bytes.len()
+        );
+
+        let summary = extract_cost_from_log(bytes);
+        assert_eq!(summary.total_cost_usd, Some(0.05));
+        // Model must be found even though it appears far into the log.
+        assert_eq!(
+            summary.model.as_deref(),
+            Some("claude-sonnet-4-20250514"),
+            "model should be extracted correctly despite large env dump prefix"
+        );
+    }
+
+    #[test]
+    fn test_extract_cost_hook_output_appended_to_main_log() {
+        // Simulates a post-hook whose NDJSON output is appended to the main command log,
+        // separated by a plain-text comment line.
+        let log = concat!(
+            // Main command Claude block
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"result","total_cost_usd":0.04,"duration_ms":800,"num_turns":2,"usage":{"input_tokens":80,"output_tokens":30}}"#,
+            "\n",
+            // Plain separator (not JSON)
+            "--- post-hook ---\n",
+            // Post-hook Claude block
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"result","total_cost_usd":0.02,"duration_ms":400,"num_turns":1,"usage":{"input_tokens":40,"output_tokens":15}}"#,
+            "\n"
+        );
+        let summary = extract_cost_from_log(log.as_bytes());
+
+        // Costs from both blocks must be summed; separator line must be ignored.
+        assert!(
+            (summary.total_cost_usd.unwrap() - 0.06).abs() < 1e-10,
+            "expected total_cost_usd ~0.06, got {:?}",
+            summary.total_cost_usd
+        );
+        assert_eq!(summary.duration_ms, Some(1200));
+        assert_eq!(summary.num_turns, Some(3));
+
+        let usage = summary.usage.expect("usage should be Some");
+        assert_eq!(usage["input_tokens"], 120);
+        assert_eq!(usage["output_tokens"], 45);
+    }
+
+    #[test]
+    fn test_extract_cost_different_models_across_invocations() {
+        // When two invocations use different models, the model field should contain
+        // only the FIRST model seen (from the first system event).
+        let log = concat!(
+            // First invocation — sonnet
+            r#"{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}"#,
+            "\n",
+            r#"{"type":"result","total_cost_usd":0.05,"duration_ms":1000,"num_turns":2,"usage":{"input_tokens":100,"output_tokens":40}}"#,
+            "\n",
+            // Second invocation — opus
+            r#"{"type":"system","subtype":"init","model":"claude-opus-4-20250514"}"#,
+            "\n",
+            r#"{"type":"result","total_cost_usd":0.20,"duration_ms":3000,"num_turns":4,"usage":{"input_tokens":400,"output_tokens":160}}"#,
+            "\n"
+        );
+        let summary = extract_cost_from_log(log.as_bytes());
+
+        // Costs are still summed across both invocations.
+        assert!(
+            (summary.total_cost_usd.unwrap() - 0.25).abs() < 1e-10,
+            "expected total_cost_usd ~0.25, got {:?}",
+            summary.total_cost_usd
+        );
+        // Model must be the FIRST one encountered.
+        assert_eq!(
+            summary.model.as_deref(),
+            Some("claude-sonnet-4-20250514"),
+            "model should be taken from the first system event"
+        );
+    }
+
+    // --- Hook cost capture integration tests ---
+
+    /// Write NDJSON content to a temp file and return a shell command that cats it.
+    /// Works cross-platform (type on Windows, cat on Unix).
+    fn ndjson_hook_command(dir: &std::path::Path, filename: &str, content: &str) -> String {
+        let file_path = dir.join(filename);
+        std::fs::write(&file_path, content).expect("write ndjson file");
+        let path_str = file_path.to_string_lossy().to_string();
+        if cfg!(target_os = "windows") {
+            // cmd.exe /C passes the command as a single argument; avoid extra
+            // quotes around the path (temp paths never contain spaces).
+            format!("type {}", path_str)
+        } else {
+            format!("cat \"{}\"", path_str)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pre_hook_claude_cost_captured() {
+        let tmp_dir = tempfile::tempdir().expect("create temp dir");
+
+        let ndjson = concat!(
+            "{\"type\":\"system\",\"subtype\":\"init\",\"model\":\"claude-sonnet-4-20250514\"}\n",
+            "{\"type\":\"result\",\"total_cost_usd\":0.05,\"duration_ms\":2000,\"num_turns\":2,\"usage\":{\"input_tokens\":500,\"output_tokens\":200}}\n"
+        );
+        let hook_cmd = ndjson_hook_command(tmp_dir.path(), "pre_hook_ndjson.txt", ndjson);
+
+        // Main command produces plain output (no Claude NDJSON)
+        let spawner = MockPtySpawner::with_output_and_exit(vec![b"done\n".to_vec()], 0);
+        let (executor, _event_rx, log_store) = setup_executor(spawner);
+
+        let mut job = make_test_job();
+        job.pre_hook = Some(hook_cmd);
+
+        let run_id = Uuid::now_v7();
+        let handle = executor
+            .spawn_job(&job, run_id, None)
+            .await
+            .expect("spawn_job");
+        handle.join_handle.await.expect("join");
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let runs = log_store.runs.read().await;
+        let run = runs
+            .iter()
+            .find(|r| r.run_id == run_id)
+            .expect("run should exist");
+
+        assert_eq!(
+            run.status,
+            RunStatus::Completed,
+            "Job should complete successfully"
+        );
+        assert_eq!(
+            run.total_cost_usd,
+            Some(0.05),
+            "Pre-hook cost should be captured. Run: {:?}",
+            run
+        );
+        assert_eq!(run.duration_ms, Some(2000));
+        assert_eq!(run.num_turns, Some(2));
+        assert_eq!(
+            run.model.as_deref(),
+            Some("claude-sonnet-4-20250514"),
+            "Model should be captured from pre-hook NDJSON"
+        );
+        assert!(
+            run.usage.is_some(),
+            "Usage should be captured from pre-hook"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_hook_claude_cost_captured() {
+        let tmp_dir = tempfile::tempdir().expect("create temp dir");
+
+        let ndjson = concat!(
+            "{\"type\":\"system\",\"subtype\":\"init\",\"model\":\"claude-sonnet-4-20250514\"}\n",
+            "{\"type\":\"result\",\"total_cost_usd\":0.08,\"duration_ms\":3000,\"num_turns\":4,\"usage\":{\"input_tokens\":800,\"output_tokens\":300}}\n"
+        );
+        let hook_cmd = ndjson_hook_command(tmp_dir.path(), "post_hook_ndjson.txt", ndjson);
+
+        // Main command produces plain output (no Claude NDJSON)
+        let spawner = MockPtySpawner::with_output_and_exit(vec![b"done\n".to_vec()], 0);
+        let (executor, _event_rx, log_store) = setup_executor(spawner);
+
+        let mut job = make_test_job();
+        job.post_hook = Some(hook_cmd);
+
+        let run_id = Uuid::now_v7();
+        let handle = executor
+            .spawn_job(&job, run_id, None)
+            .await
+            .expect("spawn_job");
+        handle.join_handle.await.expect("join");
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let runs = log_store.runs.read().await;
+        let run = runs
+            .iter()
+            .find(|r| r.run_id == run_id)
+            .expect("run should exist");
+
+        assert_eq!(
+            run.status,
+            RunStatus::Completed,
+            "Job should complete successfully"
+        );
+        // Post-hook output triggers re-extraction, so cost should be present
+        assert_eq!(
+            run.total_cost_usd,
+            Some(0.08),
+            "Post-hook cost should be captured via re-extraction. Run: {:?}",
+            run
+        );
+        assert_eq!(run.duration_ms, Some(3000));
+        assert_eq!(run.num_turns, Some(4));
+        assert_eq!(
+            run.model.as_deref(),
+            Some("claude-sonnet-4-20250514"),
+            "Model should be captured from post-hook NDJSON"
+        );
+        assert!(
+            run.usage.is_some(),
+            "Usage should be captured from post-hook"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_main_and_post_hook_costs_summed() {
+        let tmp_dir = tempfile::tempdir().expect("create temp dir");
+
+        // Post-hook NDJSON (cost = 0.03)
+        let post_ndjson = concat!(
+            "{\"type\":\"system\",\"subtype\":\"init\",\"model\":\"claude-sonnet-4-20250514\"}\n",
+            "{\"type\":\"result\",\"total_cost_usd\":0.03,\"duration_ms\":1500,\"num_turns\":1,\"usage\":{\"input_tokens\":200,\"output_tokens\":100}}\n"
+        );
+        let hook_cmd = ndjson_hook_command(tmp_dir.path(), "post_hook_sum.txt", post_ndjson);
+
+        // Main command produces Claude NDJSON via the mock PTY (cost = 0.07)
+        let main_ndjson_system =
+            b"{\"type\":\"system\",\"subtype\":\"init\",\"model\":\"claude-sonnet-4-20250514\"}\n"
+                .to_vec();
+        let main_ndjson_result =
+            b"{\"type\":\"result\",\"total_cost_usd\":0.07,\"duration_ms\":5000,\"num_turns\":3,\"usage\":{\"input_tokens\":600,\"output_tokens\":400}}\n"
+                .to_vec();
+
+        let spawner =
+            MockPtySpawner::with_output_and_exit(vec![main_ndjson_system, main_ndjson_result], 0);
+        let (executor, _event_rx, log_store) = setup_executor(spawner);
+
+        let mut job = make_test_job();
+        job.post_hook = Some(hook_cmd);
+
+        let run_id = Uuid::now_v7();
+        let handle = executor
+            .spawn_job(&job, run_id, None)
+            .await
+            .expect("spawn_job");
+        handle.join_handle.await.expect("join");
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let runs = log_store.runs.read().await;
+        let run = runs
+            .iter()
+            .find(|r| r.run_id == run_id)
+            .expect("run should exist");
+
+        assert_eq!(
+            run.status,
+            RunStatus::Completed,
+            "Job should complete successfully"
+        );
+        // Costs should be summed: 0.07 (main) + 0.03 (post-hook) = 0.10
+        let total = run.total_cost_usd.expect("total_cost_usd should be Some");
+        assert!(
+            (total - 0.10).abs() < 1e-9,
+            "Costs should be summed: expected 0.10, got {}",
+            total
+        );
+        // duration_ms should be summed: 5000 + 1500 = 6500
+        assert_eq!(
+            run.duration_ms,
+            Some(6500),
+            "Duration ms should be summed from main and post-hook"
+        );
+        // num_turns should be summed: 3 + 1 = 4
+        assert_eq!(
+            run.num_turns,
+            Some(4),
+            "Num turns should be summed from main and post-hook"
+        );
+        // Usage tokens should be summed
+        let usage = run.usage.as_ref().expect("usage should be Some");
+        assert_eq!(
+            usage["input_tokens"], 800,
+            "Input tokens should be summed: 600 + 200"
+        );
+        assert_eq!(
+            usage["output_tokens"], 500,
+            "Output tokens should be summed: 400 + 100"
+        );
     }
 }

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -1077,11 +1077,7 @@ mod tests {
             Ok(None)
         }
 
-        async fn update_manifest(
-            &self,
-            _job_id: Uuid,
-            _run: &JobRun,
-        ) -> anyhow::Result<()> {
+        async fn update_manifest(&self, _job_id: Uuid, _run: &JobRun) -> anyhow::Result<()> {
             Ok(())
         }
 

--- a/acs/src/daemon/mod.rs
+++ b/acs/src/daemon/mod.rs
@@ -1116,6 +1116,28 @@ mod tests {
         async fn cleanup(&self, _job_id: Uuid, _max_files: usize) -> anyhow::Result<()> {
             Ok(())
         }
+
+        async fn read_manifest(
+            &self,
+            _job_id: Uuid,
+        ) -> anyhow::Result<Option<crate::models::JobManifest>> {
+            Ok(None)
+        }
+
+        async fn update_manifest(
+            &self,
+            _job_id: Uuid,
+            _run: &JobRun,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn rebuild_manifest(
+            &self,
+            job_id: Uuid,
+        ) -> anyhow::Result<crate::models::JobManifest> {
+            Ok(crate::models::JobManifest::new(job_id))
+        }
     }
 
     // =======================================================================

--- a/acs/src/daemon/mod.rs
+++ b/acs/src/daemon/mod.rs
@@ -1124,11 +1124,7 @@ mod tests {
             Ok(None)
         }
 
-        async fn update_manifest(
-            &self,
-            _job_id: Uuid,
-            _run: &JobRun,
-        ) -> anyhow::Result<()> {
+        async fn update_manifest(&self, _job_id: Uuid, _run: &JobRun) -> anyhow::Result<()> {
             Ok(())
         }
 

--- a/acs/src/daemon/service.rs
+++ b/acs/src/daemon/service.rs
@@ -84,7 +84,11 @@ mod platform {
         use winreg::RegKey;
 
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-        let key = hkcu.open_subkey_with_flags(RUN_KEY_PATH, KEY_SET_VALUE)?;
+        let key = match hkcu.open_subkey_with_flags(RUN_KEY_PATH, KEY_SET_VALUE) {
+            Ok(k) => k,
+            Err(_) if !is_service_registered() => return Ok(()),
+            Err(e) => return Err(anyhow::anyhow!(e)),
+        };
 
         match key.delete_value(RUN_VALUE_NAME) {
             Ok(()) => {

--- a/acs/src/models/manifest.rs
+++ b/acs/src/models/manifest.rs
@@ -101,10 +101,14 @@ impl JobManifest {
                 model_entry.cost_usd += cost;
 
                 if let Some(usage) = &run.usage {
-                    model_entry.input_tokens +=
-                        usage.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-                    model_entry.output_tokens +=
-                        usage.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    model_entry.input_tokens += usage
+                        .get("input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    model_entry.output_tokens += usage
+                        .get("output_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
                     model_entry.cache_creation_input_tokens += usage
                         .get("cache_creation_input_tokens")
                         .and_then(|v| v.as_u64())
@@ -124,8 +128,8 @@ impl JobManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
     use crate::models::RunStatus;
+    use chrono::TimeZone;
 
     fn make_test_run(
         job_id: Uuid,
@@ -164,7 +168,13 @@ mod tests {
             "cache_creation_input_tokens": 200_u64,
             "cache_read_input_tokens": 300_u64
         });
-        let run = make_test_run(job_id, dt, Some(0.50), Some("claude-sonnet-4-20250514"), Some(usage));
+        let run = make_test_run(
+            job_id,
+            dt,
+            Some(0.50),
+            Some("claude-sonnet-4-20250514"),
+            Some(usage),
+        );
         manifest.merge_run(&run);
 
         let json = serde_json::to_string(&manifest).expect("serialize");
@@ -192,27 +202,45 @@ mod tests {
             "cache_creation_input_tokens": 200_u64,
             "cache_read_input_tokens": 300_u64
         });
-        let run = make_test_run(job_id, dt, Some(0.50), Some("claude-sonnet-4-20250514"), Some(usage));
+        let run = make_test_run(
+            job_id,
+            dt,
+            Some(0.50),
+            Some("claude-sonnet-4-20250514"),
+            Some(usage),
+        );
         manifest.merge_run(&run);
 
         assert_eq!(manifest.total_runs, 1);
         assert!((manifest.total_cost_usd - 0.50).abs() < f64::EPSILON);
 
         // Daily bucket
-        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        let daily = manifest
+            .daily_buckets
+            .get("2025-06-15")
+            .expect("daily bucket");
         assert_eq!(daily.runs, 1);
         assert!((daily.cost_usd - 0.50).abs() < f64::EPSILON);
 
         // Weekly bucket
-        let weekly = manifest.weekly_buckets.get("2025-W24").expect("weekly bucket");
+        let weekly = manifest
+            .weekly_buckets
+            .get("2025-W24")
+            .expect("weekly bucket");
         assert_eq!(weekly.runs, 1);
 
         // Monthly bucket
-        let monthly = manifest.monthly_buckets.get("2025-06").expect("monthly bucket");
+        let monthly = manifest
+            .monthly_buckets
+            .get("2025-06")
+            .expect("monthly bucket");
         assert_eq!(monthly.runs, 1);
 
         // Model entry in daily bucket
-        let model_entry = daily.models.get("claude-sonnet-4-20250514").expect("model entry");
+        let model_entry = daily
+            .models
+            .get("claude-sonnet-4-20250514")
+            .expect("model entry");
         assert_eq!(model_entry.input_tokens, 1000);
         assert_eq!(model_entry.output_tokens, 500);
         assert_eq!(model_entry.cache_creation_input_tokens, 200);
@@ -227,8 +255,20 @@ mod tests {
         let dt1 = Utc.with_ymd_and_hms(2025, 6, 15, 9, 0, 0).unwrap();
         let dt2 = Utc.with_ymd_and_hms(2025, 6, 15, 14, 0, 0).unwrap();
 
-        let run1 = make_test_run(job_id, dt1, Some(0.30), Some("claude-sonnet-4-20250514"), None);
-        let run2 = make_test_run(job_id, dt2, Some(0.20), Some("claude-sonnet-4-20250514"), None);
+        let run1 = make_test_run(
+            job_id,
+            dt1,
+            Some(0.30),
+            Some("claude-sonnet-4-20250514"),
+            None,
+        );
+        let run2 = make_test_run(
+            job_id,
+            dt2,
+            Some(0.20),
+            Some("claude-sonnet-4-20250514"),
+            None,
+        );
 
         manifest.merge_run(&run1);
         manifest.merge_run(&run2);
@@ -238,7 +278,10 @@ mod tests {
 
         // Only one daily bucket
         assert_eq!(manifest.daily_buckets.len(), 1);
-        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        let daily = manifest
+            .daily_buckets
+            .get("2025-06-15")
+            .expect("daily bucket");
         assert_eq!(daily.runs, 2);
         assert!((daily.cost_usd - 0.50).abs() < 1e-10);
 
@@ -298,7 +341,10 @@ mod tests {
         assert_eq!(manifest.total_cost_usd, 0.0);
         assert_eq!(manifest.total_duration_ms, 0);
 
-        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        let daily = manifest
+            .daily_buckets
+            .get("2025-06-15")
+            .expect("daily bucket");
         assert_eq!(daily.runs, 1);
         assert_eq!(daily.cost_usd, 0.0);
         assert!(daily.models.is_empty());
@@ -316,7 +362,13 @@ mod tests {
             "cache_creation_input_tokens": 200_u64,
             "cache_read_input_tokens": 300_u64
         });
-        let run = make_test_run(job_id, dt, Some(0.75), Some("claude-sonnet-4-20250514"), Some(usage));
+        let run = make_test_run(
+            job_id,
+            dt,
+            Some(0.75),
+            Some("claude-sonnet-4-20250514"),
+            Some(usage),
+        );
         manifest.merge_run(&run);
 
         // Check all three time bucket levels
@@ -326,7 +378,10 @@ mod tests {
             &manifest.monthly_buckets,
         ] {
             let bucket = bucket_map.values().next().expect("bucket exists");
-            let model_entry = bucket.models.get("claude-sonnet-4-20250514").expect("model entry");
+            let model_entry = bucket
+                .models
+                .get("claude-sonnet-4-20250514")
+                .expect("model entry");
             assert_eq!(model_entry.runs, 1);
             assert!((model_entry.cost_usd - 0.75).abs() < f64::EPSILON);
             assert_eq!(model_entry.input_tokens, 1000);
@@ -349,7 +404,13 @@ mod tests {
             "cache_creation_input_tokens": 0_u64,
             "cache_read_input_tokens": 0_u64
         });
-        let run1 = make_test_run(job_id, dt, Some(0.10), Some("claude-sonnet-4-20250514"), Some(usage1));
+        let run1 = make_test_run(
+            job_id,
+            dt,
+            Some(0.10),
+            Some("claude-sonnet-4-20250514"),
+            Some(usage1),
+        );
 
         let usage2 = serde_json::json!({
             "input_tokens": 200_u64,
@@ -357,15 +418,27 @@ mod tests {
             "cache_creation_input_tokens": 0_u64,
             "cache_read_input_tokens": 0_u64
         });
-        let run2 = make_test_run(job_id, dt, Some(0.20), Some("claude-opus-4-5"), Some(usage2));
+        let run2 = make_test_run(
+            job_id,
+            dt,
+            Some(0.20),
+            Some("claude-opus-4-5"),
+            Some(usage2),
+        );
 
         manifest.merge_run(&run1);
         manifest.merge_run(&run2);
 
-        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        let daily = manifest
+            .daily_buckets
+            .get("2025-06-15")
+            .expect("daily bucket");
         assert_eq!(daily.models.len(), 2);
 
-        let sonnet = daily.models.get("claude-sonnet-4-20250514").expect("sonnet entry");
+        let sonnet = daily
+            .models
+            .get("claude-sonnet-4-20250514")
+            .expect("sonnet entry");
         assert_eq!(sonnet.runs, 1);
         assert_eq!(sonnet.input_tokens, 100);
         assert_eq!(sonnet.output_tokens, 50);

--- a/acs/src/models/manifest.rs
+++ b/acs/src/models/manifest.rs
@@ -1,0 +1,122 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::JobRun;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default)]
+pub struct ModelUsageBucket {
+    pub runs: u64,
+    pub cost_usd: f64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub cache_read_input_tokens: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default)]
+pub struct TimeBucket {
+    pub runs: u64,
+    pub cost_usd: f64,
+    pub duration_ms: u64,
+    pub num_turns: u64,
+    pub models: BTreeMap<String, ModelUsageBucket>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct JobManifest {
+    pub job_id: Uuid,
+    pub version: u32,
+    pub updated_at: DateTime<Utc>,
+    pub total_runs: u64,
+    pub total_cost_usd: f64,
+    pub total_duration_ms: u64,
+    pub daily_buckets: BTreeMap<String, TimeBucket>,
+    pub weekly_buckets: BTreeMap<String, TimeBucket>,
+    pub monthly_buckets: BTreeMap<String, TimeBucket>,
+}
+
+impl Default for JobManifest {
+    fn default() -> Self {
+        Self {
+            job_id: Uuid::nil(),
+            version: 1,
+            updated_at: Utc::now(),
+            total_runs: 0,
+            total_cost_usd: 0.0,
+            total_duration_ms: 0,
+            daily_buckets: BTreeMap::new(),
+            weekly_buckets: BTreeMap::new(),
+            monthly_buckets: BTreeMap::new(),
+        }
+    }
+}
+
+impl JobManifest {
+    pub fn new(job_id: Uuid) -> Self {
+        Self {
+            job_id,
+            version: 1,
+            updated_at: Utc::now(),
+            total_runs: 0,
+            total_cost_usd: 0.0,
+            total_duration_ms: 0,
+            daily_buckets: BTreeMap::new(),
+            weekly_buckets: BTreeMap::new(),
+            monthly_buckets: BTreeMap::new(),
+        }
+    }
+
+    pub fn merge_run(&mut self, run: &JobRun) {
+        let cost = run.total_cost_usd.unwrap_or(0.0);
+        let duration = run.duration_ms.unwrap_or(0);
+        let turns = run.num_turns.unwrap_or(0) as u64;
+
+        self.total_runs += 1;
+        self.total_cost_usd += cost;
+        self.total_duration_ms += duration;
+
+        let daily_key = run.started_at.format("%Y-%m-%d").to_string();
+        let weekly_key = run.started_at.format("%G-W%V").to_string();
+        let monthly_key = run.started_at.format("%Y-%m").to_string();
+
+        for bucket in [
+            self.daily_buckets.entry(daily_key).or_default(),
+            self.weekly_buckets.entry(weekly_key).or_default(),
+            self.monthly_buckets.entry(monthly_key).or_default(),
+        ] {
+            bucket.runs += 1;
+            bucket.cost_usd += cost;
+            bucket.duration_ms += duration;
+            bucket.num_turns += turns;
+
+            if let Some(model_name) = &run.model {
+                let model_entry = bucket.models.entry(model_name.clone()).or_default();
+                model_entry.runs += 1;
+                model_entry.cost_usd += cost;
+
+                if let Some(usage) = &run.usage {
+                    model_entry.input_tokens +=
+                        usage.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    model_entry.output_tokens +=
+                        usage.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    model_entry.cache_creation_input_tokens += usage
+                        .get("cache_creation_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    model_entry.cache_read_input_tokens += usage
+                        .get("cache_read_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                }
+            }
+        }
+
+        self.updated_at = Utc::now();
+    }
+}

--- a/acs/src/models/manifest.rs
+++ b/acs/src/models/manifest.rs
@@ -120,3 +120,279 @@ impl JobManifest {
         self.updated_at = Utc::now();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use crate::models::RunStatus;
+
+    fn make_test_run(
+        job_id: Uuid,
+        started_at: DateTime<Utc>,
+        cost: Option<f64>,
+        model: Option<&str>,
+        usage: Option<serde_json::Value>,
+    ) -> JobRun {
+        crate::models::JobRun {
+            run_id: Uuid::now_v7(),
+            job_id,
+            started_at,
+            finished_at: Some(started_at + chrono::Duration::seconds(60)),
+            status: RunStatus::Completed,
+            exit_code: Some(0),
+            log_size_bytes: 512,
+            error: None,
+            trigger_params: None,
+            total_cost_usd: cost,
+            duration_ms: cost.map(|_| 1000),
+            num_turns: Some(3),
+            model: model.map(|s| s.to_string()),
+            usage,
+        }
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let job_id = Uuid::now_v7();
+        let mut manifest = JobManifest::new(job_id);
+
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+        let usage = serde_json::json!({
+            "input_tokens": 1000_u64,
+            "output_tokens": 500_u64,
+            "cache_creation_input_tokens": 200_u64,
+            "cache_read_input_tokens": 300_u64
+        });
+        let run = make_test_run(job_id, dt, Some(0.50), Some("claude-sonnet-4-20250514"), Some(usage));
+        manifest.merge_run(&run);
+
+        let json = serde_json::to_string(&manifest).expect("serialize");
+        let deserialized: JobManifest = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(manifest.job_id, deserialized.job_id);
+        assert_eq!(manifest.version, deserialized.version);
+        assert_eq!(manifest.total_runs, deserialized.total_runs);
+        assert_eq!(manifest.total_cost_usd, deserialized.total_cost_usd);
+        assert_eq!(manifest.total_duration_ms, deserialized.total_duration_ms);
+        assert_eq!(manifest.daily_buckets, deserialized.daily_buckets);
+        assert_eq!(manifest.weekly_buckets, deserialized.weekly_buckets);
+        assert_eq!(manifest.monthly_buckets, deserialized.monthly_buckets);
+    }
+
+    #[test]
+    fn test_merge_single_run() {
+        let job_id = Uuid::now_v7();
+        let mut manifest = JobManifest::new(job_id);
+
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+        let usage = serde_json::json!({
+            "input_tokens": 1000_u64,
+            "output_tokens": 500_u64,
+            "cache_creation_input_tokens": 200_u64,
+            "cache_read_input_tokens": 300_u64
+        });
+        let run = make_test_run(job_id, dt, Some(0.50), Some("claude-sonnet-4-20250514"), Some(usage));
+        manifest.merge_run(&run);
+
+        assert_eq!(manifest.total_runs, 1);
+        assert!((manifest.total_cost_usd - 0.50).abs() < f64::EPSILON);
+
+        // Daily bucket
+        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        assert_eq!(daily.runs, 1);
+        assert!((daily.cost_usd - 0.50).abs() < f64::EPSILON);
+
+        // Weekly bucket
+        let weekly = manifest.weekly_buckets.get("2025-W24").expect("weekly bucket");
+        assert_eq!(weekly.runs, 1);
+
+        // Monthly bucket
+        let monthly = manifest.monthly_buckets.get("2025-06").expect("monthly bucket");
+        assert_eq!(monthly.runs, 1);
+
+        // Model entry in daily bucket
+        let model_entry = daily.models.get("claude-sonnet-4-20250514").expect("model entry");
+        assert_eq!(model_entry.input_tokens, 1000);
+        assert_eq!(model_entry.output_tokens, 500);
+        assert_eq!(model_entry.cache_creation_input_tokens, 200);
+        assert_eq!(model_entry.cache_read_input_tokens, 300);
+    }
+
+    #[test]
+    fn test_merge_multiple_runs_same_day() {
+        let job_id = Uuid::now_v7();
+        let mut manifest = JobManifest::new(job_id);
+
+        let dt1 = Utc.with_ymd_and_hms(2025, 6, 15, 9, 0, 0).unwrap();
+        let dt2 = Utc.with_ymd_and_hms(2025, 6, 15, 14, 0, 0).unwrap();
+
+        let run1 = make_test_run(job_id, dt1, Some(0.30), Some("claude-sonnet-4-20250514"), None);
+        let run2 = make_test_run(job_id, dt2, Some(0.20), Some("claude-sonnet-4-20250514"), None);
+
+        manifest.merge_run(&run1);
+        manifest.merge_run(&run2);
+
+        assert_eq!(manifest.total_runs, 2);
+        assert!((manifest.total_cost_usd - 0.50).abs() < 1e-10);
+
+        // Only one daily bucket
+        assert_eq!(manifest.daily_buckets.len(), 1);
+        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        assert_eq!(daily.runs, 2);
+        assert!((daily.cost_usd - 0.50).abs() < 1e-10);
+
+        // Only one weekly bucket
+        assert_eq!(manifest.weekly_buckets.len(), 1);
+        // Only one monthly bucket
+        assert_eq!(manifest.monthly_buckets.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_multiple_runs_different_days() {
+        let job_id = Uuid::now_v7();
+        let mut manifest = JobManifest::new(job_id);
+
+        // 2025-06-15 → week 24, month 06
+        let dt1 = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+        // 2025-06-16 → week 25, month 06
+        let dt2 = Utc.with_ymd_and_hms(2025, 6, 16, 10, 0, 0).unwrap();
+        // 2025-06-20 → week 25, month 06
+        let dt3 = Utc.with_ymd_and_hms(2025, 6, 20, 10, 0, 0).unwrap();
+
+        manifest.merge_run(&make_test_run(job_id, dt1, Some(0.10), None, None));
+        manifest.merge_run(&make_test_run(job_id, dt2, Some(0.20), None, None));
+        manifest.merge_run(&make_test_run(job_id, dt3, Some(0.30), None, None));
+
+        assert_eq!(manifest.total_runs, 3);
+
+        // 3 separate daily buckets
+        assert_eq!(manifest.daily_buckets.len(), 3);
+        assert!(manifest.daily_buckets.contains_key("2025-06-15"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-16"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-20"));
+
+        // 2 weekly buckets: W24 (only 6/15) and W25 (6/16 + 6/20)
+        assert_eq!(manifest.weekly_buckets.len(), 2);
+        let w24 = manifest.weekly_buckets.get("2025-W24").expect("week 24");
+        assert_eq!(w24.runs, 1);
+        let w25 = manifest.weekly_buckets.get("2025-W25").expect("week 25");
+        assert_eq!(w25.runs, 2);
+
+        // 1 monthly bucket: all in June
+        assert_eq!(manifest.monthly_buckets.len(), 1);
+        let june = manifest.monthly_buckets.get("2025-06").expect("june");
+        assert_eq!(june.runs, 3);
+    }
+
+    #[test]
+    fn test_merge_run_no_cost_data() {
+        let job_id = Uuid::now_v7();
+        let mut manifest = JobManifest::new(job_id);
+
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+        let run = make_test_run(job_id, dt, None, None, None);
+        manifest.merge_run(&run);
+
+        assert_eq!(manifest.total_runs, 1);
+        assert_eq!(manifest.total_cost_usd, 0.0);
+        assert_eq!(manifest.total_duration_ms, 0);
+
+        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        assert_eq!(daily.runs, 1);
+        assert_eq!(daily.cost_usd, 0.0);
+        assert!(daily.models.is_empty());
+    }
+
+    #[test]
+    fn test_per_model_token_breakdown() {
+        let job_id = Uuid::now_v7();
+        let mut manifest = JobManifest::new(job_id);
+
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+        let usage = serde_json::json!({
+            "input_tokens": 1000_u64,
+            "output_tokens": 500_u64,
+            "cache_creation_input_tokens": 200_u64,
+            "cache_read_input_tokens": 300_u64
+        });
+        let run = make_test_run(job_id, dt, Some(0.75), Some("claude-sonnet-4-20250514"), Some(usage));
+        manifest.merge_run(&run);
+
+        // Check all three time bucket levels
+        for bucket_map in [
+            &manifest.daily_buckets,
+            &manifest.weekly_buckets,
+            &manifest.monthly_buckets,
+        ] {
+            let bucket = bucket_map.values().next().expect("bucket exists");
+            let model_entry = bucket.models.get("claude-sonnet-4-20250514").expect("model entry");
+            assert_eq!(model_entry.runs, 1);
+            assert!((model_entry.cost_usd - 0.75).abs() < f64::EPSILON);
+            assert_eq!(model_entry.input_tokens, 1000);
+            assert_eq!(model_entry.output_tokens, 500);
+            assert_eq!(model_entry.cache_creation_input_tokens, 200);
+            assert_eq!(model_entry.cache_read_input_tokens, 300);
+        }
+    }
+
+    #[test]
+    fn test_multiple_models() {
+        let job_id = Uuid::now_v7();
+        let mut manifest = JobManifest::new(job_id);
+
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+
+        let usage1 = serde_json::json!({
+            "input_tokens": 100_u64,
+            "output_tokens": 50_u64,
+            "cache_creation_input_tokens": 0_u64,
+            "cache_read_input_tokens": 0_u64
+        });
+        let run1 = make_test_run(job_id, dt, Some(0.10), Some("claude-sonnet-4-20250514"), Some(usage1));
+
+        let usage2 = serde_json::json!({
+            "input_tokens": 200_u64,
+            "output_tokens": 100_u64,
+            "cache_creation_input_tokens": 0_u64,
+            "cache_read_input_tokens": 0_u64
+        });
+        let run2 = make_test_run(job_id, dt, Some(0.20), Some("claude-opus-4-5"), Some(usage2));
+
+        manifest.merge_run(&run1);
+        manifest.merge_run(&run2);
+
+        let daily = manifest.daily_buckets.get("2025-06-15").expect("daily bucket");
+        assert_eq!(daily.models.len(), 2);
+
+        let sonnet = daily.models.get("claude-sonnet-4-20250514").expect("sonnet entry");
+        assert_eq!(sonnet.runs, 1);
+        assert_eq!(sonnet.input_tokens, 100);
+        assert_eq!(sonnet.output_tokens, 50);
+
+        let opus = daily.models.get("claude-opus-4-5").expect("opus entry");
+        assert_eq!(opus.runs, 1);
+        assert_eq!(opus.input_tokens, 200);
+        assert_eq!(opus.output_tokens, 100);
+    }
+
+    #[test]
+    fn test_backward_compat_deserialize() {
+        // A minimal manifest JSON missing newer optional fields should deserialize with defaults
+        let json = r#"{
+            "job_id": "01234567-8901-2345-6789-012345678901",
+            "version": 1,
+            "updated_at": "2025-06-15T10:00:00Z",
+            "total_runs": 5,
+            "total_cost_usd": 1.25
+        }"#;
+
+        let manifest: JobManifest = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(manifest.total_runs, 5);
+        assert!((manifest.total_cost_usd - 1.25).abs() < f64::EPSILON);
+        assert_eq!(manifest.total_duration_ms, 0);
+        assert!(manifest.daily_buckets.is_empty());
+        assert!(manifest.weekly_buckets.is_empty());
+        assert!(manifest.monthly_buckets.is_empty());
+    }
+}

--- a/acs/src/models/mod.rs
+++ b/acs/src/models/mod.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod dispatch;
 pub mod job;
+pub mod manifest;
 pub mod run;
 
 pub use config::DaemonConfig;
 pub use dispatch::{DispatchRequest, TriggerParams};
 pub use job::{ExecutionType, Job, JobUpdate, NewJob};
+pub use manifest::JobManifest;
 pub use run::{JobRun, RunStatus};

--- a/acs/src/server/mod.rs
+++ b/acs/src/server/mod.rs
@@ -281,11 +281,7 @@ mod tests {
             Ok(None)
         }
 
-        async fn update_manifest(
-            &self,
-            _job_id: Uuid,
-            _run: &JobRun,
-        ) -> anyhow::Result<()> {
+        async fn update_manifest(&self, _job_id: Uuid, _run: &JobRun) -> anyhow::Result<()> {
             Ok(())
         }
 

--- a/acs/src/server/mod.rs
+++ b/acs/src/server/mod.rs
@@ -273,6 +273,28 @@ mod tests {
         async fn cleanup(&self, _job_id: Uuid, _max_files: usize) -> anyhow::Result<()> {
             Ok(())
         }
+
+        async fn read_manifest(
+            &self,
+            _job_id: Uuid,
+        ) -> anyhow::Result<Option<crate::models::JobManifest>> {
+            Ok(None)
+        }
+
+        async fn update_manifest(
+            &self,
+            _job_id: Uuid,
+            _run: &JobRun,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn rebuild_manifest(
+            &self,
+            job_id: Uuid,
+        ) -> anyhow::Result<crate::models::JobManifest> {
+            Ok(crate::models::JobManifest::new(job_id))
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/acs/src/storage/logs.rs
+++ b/acs/src/storage/logs.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use uuid::Uuid;
 
+use crate::models::manifest::JobManifest;
 use crate::models::JobRun;
 use crate::storage::LogStore;
 
@@ -34,6 +35,11 @@ impl FsLogStore {
     /// Get the path to a run's log file.
     fn log_path(&self, job_id: Uuid, run_id: Uuid) -> PathBuf {
         self.job_dir(job_id).join(format!("{}.log", run_id))
+    }
+
+    /// Get the path to a job's manifest file.
+    fn manifest_path(&self, job_id: Uuid) -> PathBuf {
+        self.job_dir(job_id).join("manifest.json")
     }
 }
 
@@ -210,6 +216,130 @@ impl LogStore for FsLogStore {
         }
 
         Ok(())
+    }
+
+    async fn read_manifest(&self, job_id: Uuid) -> Result<Option<JobManifest>> {
+        let path = self.manifest_path(job_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .context("Failed to read manifest file")?;
+
+        match serde_json::from_str::<JobManifest>(&content) {
+            Ok(manifest) => Ok(Some(manifest)),
+            Err(e) => {
+                tracing::warn!("Corrupt manifest file {:?}: {}", path, e);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn update_manifest(&self, job_id: Uuid, run: &JobRun) -> Result<()> {
+        let mut manifest = self
+            .read_manifest(job_id)
+            .await?
+            .unwrap_or_else(|| JobManifest::new(job_id));
+
+        manifest.merge_run(run);
+
+        let json =
+            serde_json::to_string_pretty(&manifest).context("Failed to serialize manifest")?;
+
+        let job_dir = self.job_dir(job_id);
+        tokio::fs::create_dir_all(&job_dir)
+            .await
+            .context("Failed to create job directory")?;
+
+        let manifest_path = self.manifest_path(job_id);
+        let tmp_path = job_dir.join("manifest.json.tmp");
+
+        tokio::fs::write(&tmp_path, json.as_bytes())
+            .await
+            .context("Failed to write temporary manifest file")?;
+
+        // On Windows, rename fails if the target exists, so remove it first
+        if manifest_path.exists() {
+            tokio::fs::remove_file(&manifest_path)
+                .await
+                .context("Failed to remove existing manifest file")?;
+        }
+
+        tokio::fs::rename(&tmp_path, &manifest_path)
+            .await
+            .context("Failed to rename temporary manifest file")?;
+
+        Ok(())
+    }
+
+    async fn rebuild_manifest(&self, job_id: Uuid) -> Result<JobManifest> {
+        let mut manifest = JobManifest::new(job_id);
+        let job_dir = self.job_dir(job_id);
+
+        if job_dir.exists() {
+            let mut runs = Vec::new();
+            let mut entries = tokio::fs::read_dir(&job_dir)
+                .await
+                .context("Failed to read job log directory")?;
+
+            while let Some(entry) = entries.next_entry().await? {
+                let path = entry.path();
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name.ends_with(".meta.json") {
+                        let content = tokio::fs::read_to_string(&path)
+                            .await
+                            .context("Failed to read run metadata")?;
+                        match serde_json::from_str::<JobRun>(&content) {
+                            Ok(run) => runs.push(run),
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Skipping malformed meta file {:?}: {}",
+                                    path,
+                                    e
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Sort by started_at ascending for deterministic bucket ordering
+            runs.sort_by(|a, b| a.started_at.cmp(&b.started_at));
+
+            for run in &runs {
+                manifest.merge_run(run);
+            }
+        }
+
+        // Write atomically
+        let json =
+            serde_json::to_string_pretty(&manifest).context("Failed to serialize manifest")?;
+
+        tokio::fs::create_dir_all(&job_dir)
+            .await
+            .context("Failed to create job directory")?;
+
+        let manifest_path = self.manifest_path(job_id);
+        let tmp_path = job_dir.join("manifest.json.tmp");
+
+        tokio::fs::write(&tmp_path, json.as_bytes())
+            .await
+            .context("Failed to write temporary manifest file")?;
+
+        // On Windows, rename fails if the target exists, so remove it first
+        if manifest_path.exists() {
+            tokio::fs::remove_file(&manifest_path)
+                .await
+                .context("Failed to remove existing manifest file")?;
+        }
+
+        tokio::fs::rename(&tmp_path, &manifest_path)
+            .await
+            .context("Failed to rename temporary manifest file")?;
+
+        Ok(manifest)
     }
 }
 

--- a/acs/src/storage/logs.rs
+++ b/acs/src/storage/logs.rs
@@ -347,7 +347,7 @@ impl LogStore for FsLogStore {
 mod tests {
     use super::*;
     use crate::models::RunStatus;
-    use chrono::Utc;
+    use chrono::{TimeZone, Utc};
     use tempfile::TempDir;
 
     fn make_job_run(job_id: Uuid) -> JobRun {
@@ -365,6 +365,30 @@ mod tests {
             duration_ms: None,
             num_turns: None,
             model: None,
+            usage: None,
+        }
+    }
+
+    fn make_job_run_with_cost(
+        job_id: Uuid,
+        cost: f64,
+        model: &str,
+        started_at: chrono::DateTime<Utc>,
+    ) -> JobRun {
+        JobRun {
+            run_id: Uuid::now_v7(),
+            job_id,
+            started_at,
+            finished_at: Some(started_at + chrono::Duration::seconds(60)),
+            status: RunStatus::Completed,
+            exit_code: Some(0),
+            log_size_bytes: 0,
+            error: None,
+            trigger_params: None,
+            total_cost_usd: Some(cost),
+            duration_ms: Some(1000),
+            num_turns: Some(3),
+            model: Some(model.to_string()),
             usage: None,
         }
     }
@@ -638,5 +662,163 @@ mod tests {
         // Cleanup on a job that has no log directory should succeed silently
         let result = store.cleanup(Uuid::now_v7(), 5).await;
         assert!(result.is_ok());
+    }
+
+    // --- Manifest integration tests ---
+
+    #[tokio::test]
+    async fn test_read_manifest_returns_none_when_no_manifest() {
+        let (store, _tmp, job_id) = setup_store().await;
+        let result = store.read_manifest(job_id).await.expect("read_manifest");
+        assert!(result.is_none(), "Expected None when no manifest file exists");
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_creates_on_first_run() {
+        let (store, _tmp, job_id) = setup_store().await;
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+        let run = make_job_run_with_cost(job_id, 0.50, "claude-sonnet-4-20250514", dt);
+
+        store.create_run(&run).await.expect("create_run");
+        store.update_manifest(job_id, &run).await.expect("update_manifest");
+
+        let manifest = store
+            .read_manifest(job_id)
+            .await
+            .expect("read_manifest")
+            .expect("manifest should exist");
+
+        assert_eq!(manifest.total_runs, 1);
+        assert!((manifest.total_cost_usd - 0.50).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_accumulates_multiple_runs() {
+        let (store, _tmp, job_id) = setup_store().await;
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+
+        let costs = [0.50, 0.75, 1.25];
+        for cost in costs {
+            let run = make_job_run_with_cost(job_id, cost, "claude-sonnet-4-20250514", dt);
+            store.create_run(&run).await.expect("create_run");
+            store.update_manifest(job_id, &run).await.expect("update_manifest");
+        }
+
+        let manifest = store
+            .read_manifest(job_id)
+            .await
+            .expect("read_manifest")
+            .expect("manifest should exist");
+
+        assert_eq!(manifest.total_runs, 3);
+        assert!((manifest.total_cost_usd - 2.50).abs() < 1e-10);
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_manifest_reconstructs_from_meta_files() {
+        let (store, _tmp, job_id) = setup_store().await;
+
+        let dates = [
+            Utc.with_ymd_and_hms(2025, 6, 10, 10, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2025, 6, 11, 10, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2025, 6, 12, 10, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2025, 6, 13, 10, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2025, 6, 14, 10, 0, 0).unwrap(),
+        ];
+        let costs = [0.10, 0.20, 0.30, 0.40, 0.50];
+        let expected_total: f64 = costs.iter().sum();
+
+        for (dt, cost) in dates.iter().zip(costs.iter()) {
+            let run = make_job_run_with_cost(job_id, *cost, "claude-sonnet-4-20250514", *dt);
+            store.create_run(&run).await.expect("create_run");
+        }
+
+        let manifest = store.rebuild_manifest(job_id).await.expect("rebuild_manifest");
+
+        assert_eq!(manifest.total_runs, 5);
+        assert!((manifest.total_cost_usd - expected_total).abs() < 1e-10);
+
+        // Each date should have a daily bucket
+        assert!(manifest.daily_buckets.contains_key("2025-06-10"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-11"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-12"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-13"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-14"));
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_manifest_handles_malformed_meta_files() {
+        let (store, tmp, job_id) = setup_store().await;
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+
+        // Create 2 valid runs
+        for cost in [0.30, 0.40] {
+            let run = make_job_run_with_cost(job_id, cost, "claude-sonnet-4-20250514", dt);
+            store.create_run(&run).await.expect("create_run");
+        }
+
+        // Write a corrupt .meta.json file into the job directory
+        let job_dir = tmp.path().join("logs").join(job_id.to_string());
+        let corrupt_path = job_dir.join("corrupt-run-id.meta.json");
+        tokio::fs::write(&corrupt_path, b"{ this is not valid json !!!")
+            .await
+            .expect("write corrupt file");
+
+        // rebuild_manifest should succeed, skipping the corrupt file
+        let manifest = store.rebuild_manifest(job_id).await.expect("rebuild_manifest");
+
+        assert_eq!(manifest.total_runs, 2, "Corrupt file should be skipped");
+    }
+
+    #[tokio::test]
+    async fn test_manifest_multiple_days_buckets() {
+        let (store, _tmp, job_id) = setup_store().await;
+
+        let dates = [
+            Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2025, 6, 16, 10, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2025, 6, 17, 10, 0, 0).unwrap(),
+        ];
+
+        for dt in dates {
+            let run = make_job_run_with_cost(job_id, 0.10, "claude-sonnet-4-20250514", dt);
+            store.create_run(&run).await.expect("create_run");
+            store.update_manifest(job_id, &run).await.expect("update_manifest");
+        }
+
+        let manifest = store
+            .read_manifest(job_id)
+            .await
+            .expect("read_manifest")
+            .expect("manifest should exist");
+
+        assert_eq!(manifest.daily_buckets.len(), 3);
+        assert!(manifest.daily_buckets.contains_key("2025-06-15"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-16"));
+        assert!(manifest.daily_buckets.contains_key("2025-06-17"));
+
+        for (key, bucket) in &manifest.daily_buckets {
+            assert_eq!(bucket.runs, 1, "Daily bucket {} should have 1 run", key);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_no_tmp_file_left() {
+        let (store, tmp, job_id) = setup_store().await;
+        let dt = Utc.with_ymd_and_hms(2025, 6, 15, 10, 0, 0).unwrap();
+        let run = make_job_run_with_cost(job_id, 0.50, "claude-sonnet-4-20250514", dt);
+
+        store.create_run(&run).await.expect("create_run");
+        store.update_manifest(job_id, &run).await.expect("update_manifest");
+
+        let job_dir = tmp.path().join("logs").join(job_id.to_string());
+        let manifest_path = job_dir.join("manifest.json");
+        let tmp_path = job_dir.join("manifest.json.tmp");
+
+        assert!(manifest_path.exists(), "manifest.json should exist");
+        assert!(
+            !tmp_path.exists(),
+            "manifest.json.tmp should not exist after atomic write"
+        );
     }
 }

--- a/acs/src/storage/logs.rs
+++ b/acs/src/storage/logs.rs
@@ -294,11 +294,7 @@ impl LogStore for FsLogStore {
                         match serde_json::from_str::<JobRun>(&content) {
                             Ok(run) => runs.push(run),
                             Err(e) => {
-                                tracing::warn!(
-                                    "Skipping malformed meta file {:?}: {}",
-                                    path,
-                                    e
-                                );
+                                tracing::warn!("Skipping malformed meta file {:?}: {}", path, e);
                             }
                         }
                     }
@@ -670,7 +666,10 @@ mod tests {
     async fn test_read_manifest_returns_none_when_no_manifest() {
         let (store, _tmp, job_id) = setup_store().await;
         let result = store.read_manifest(job_id).await.expect("read_manifest");
-        assert!(result.is_none(), "Expected None when no manifest file exists");
+        assert!(
+            result.is_none(),
+            "Expected None when no manifest file exists"
+        );
     }
 
     #[tokio::test]
@@ -680,7 +679,10 @@ mod tests {
         let run = make_job_run_with_cost(job_id, 0.50, "claude-sonnet-4-20250514", dt);
 
         store.create_run(&run).await.expect("create_run");
-        store.update_manifest(job_id, &run).await.expect("update_manifest");
+        store
+            .update_manifest(job_id, &run)
+            .await
+            .expect("update_manifest");
 
         let manifest = store
             .read_manifest(job_id)
@@ -701,7 +703,10 @@ mod tests {
         for cost in costs {
             let run = make_job_run_with_cost(job_id, cost, "claude-sonnet-4-20250514", dt);
             store.create_run(&run).await.expect("create_run");
-            store.update_manifest(job_id, &run).await.expect("update_manifest");
+            store
+                .update_manifest(job_id, &run)
+                .await
+                .expect("update_manifest");
         }
 
         let manifest = store
@@ -733,7 +738,10 @@ mod tests {
             store.create_run(&run).await.expect("create_run");
         }
 
-        let manifest = store.rebuild_manifest(job_id).await.expect("rebuild_manifest");
+        let manifest = store
+            .rebuild_manifest(job_id)
+            .await
+            .expect("rebuild_manifest");
 
         assert_eq!(manifest.total_runs, 5);
         assert!((manifest.total_cost_usd - expected_total).abs() < 1e-10);
@@ -765,7 +773,10 @@ mod tests {
             .expect("write corrupt file");
 
         // rebuild_manifest should succeed, skipping the corrupt file
-        let manifest = store.rebuild_manifest(job_id).await.expect("rebuild_manifest");
+        let manifest = store
+            .rebuild_manifest(job_id)
+            .await
+            .expect("rebuild_manifest");
 
         assert_eq!(manifest.total_runs, 2, "Corrupt file should be skipped");
     }
@@ -783,7 +794,10 @@ mod tests {
         for dt in dates {
             let run = make_job_run_with_cost(job_id, 0.10, "claude-sonnet-4-20250514", dt);
             store.create_run(&run).await.expect("create_run");
-            store.update_manifest(job_id, &run).await.expect("update_manifest");
+            store
+                .update_manifest(job_id, &run)
+                .await
+                .expect("update_manifest");
         }
 
         let manifest = store
@@ -809,7 +823,10 @@ mod tests {
         let run = make_job_run_with_cost(job_id, 0.50, "claude-sonnet-4-20250514", dt);
 
         store.create_run(&run).await.expect("create_run");
-        store.update_manifest(job_id, &run).await.expect("update_manifest");
+        store
+            .update_manifest(job_id, &run)
+            .await
+            .expect("update_manifest");
 
         let job_dir = tmp.path().join("logs").join(job_id.to_string());
         let manifest_path = job_dir.join("manifest.json");

--- a/acs/src/storage/mod.rs
+++ b/acs/src/storage/mod.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::models::{Job, JobRun, JobUpdate, NewJob};
+use crate::models::{Job, JobManifest, JobRun, JobUpdate, NewJob};
 
 #[async_trait]
 pub trait JobStore: Send + Sync {
@@ -30,4 +30,7 @@ pub trait LogStore: Send + Sync {
         offset: usize,
     ) -> Result<(Vec<JobRun>, usize)>;
     async fn cleanup(&self, job_id: Uuid, max_files: usize) -> Result<()>;
+    async fn read_manifest(&self, job_id: Uuid) -> Result<Option<JobManifest>>;
+    async fn update_manifest(&self, job_id: Uuid, run: &JobRun) -> Result<()>;
+    async fn rebuild_manifest(&self, job_id: Uuid) -> Result<JobManifest>;
 }

--- a/acs/tests/api_tests.rs
+++ b/acs/tests/api_tests.rs
@@ -9,7 +9,9 @@ use std::time::Instant;
 
 use agent_cron_scheduler::daemon::events::JobEvent;
 use agent_cron_scheduler::daemon::executor::Executor;
-use agent_cron_scheduler::models::{DaemonConfig, DispatchRequest, Job, JobRun, JobUpdate, NewJob};
+use agent_cron_scheduler::models::{
+    DaemonConfig, DispatchRequest, Job, JobManifest, JobRun, JobUpdate, NewJob,
+};
 use agent_cron_scheduler::pty::MockPtySpawner;
 use agent_cron_scheduler::server::{self, AppState};
 use agent_cron_scheduler::storage::{JobStore, LogStore};
@@ -169,6 +171,15 @@ impl LogStore for InMemoryLogStore {
     async fn cleanup(&self, _job_id: Uuid, _max_files: usize) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn read_manifest(&self, _job_id: Uuid) -> anyhow::Result<Option<JobManifest>> {
+        Ok(None)
+    }
+    async fn update_manifest(&self, _job_id: Uuid, _run: &JobRun) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn rebuild_manifest(&self, _job_id: Uuid) -> anyhow::Result<JobManifest> {
+        Ok(JobManifest::new(_job_id))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -229,6 +240,15 @@ impl LogStore for StoringLogStore {
     }
     async fn cleanup(&self, _job_id: Uuid, _max_files: usize) -> anyhow::Result<()> {
         Ok(())
+    }
+    async fn read_manifest(&self, _job_id: Uuid) -> anyhow::Result<Option<JobManifest>> {
+        Ok(None)
+    }
+    async fn update_manifest(&self, _job_id: Uuid, _run: &JobRun) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn rebuild_manifest(&self, _job_id: Uuid) -> anyhow::Result<JobManifest> {
+        Ok(JobManifest::new(_job_id))
     }
 }
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -18,6 +18,7 @@ the **data directory** (`{data_dir}`).
 ├── scripts/             # Reserved directory (created on startup; not currently used for ScriptFile path resolution)
 └── logs/
     └── {job_id}/        # One directory per job, named by UUID
+        ├── manifest.json         # Aggregated cost/token/runtime statistics across all runs
         ├── {run_id}.log          # Combined process output for a single run
         └── {run_id}.meta.json    # Structured metadata for a single run
 ```
@@ -396,6 +397,9 @@ pub trait LogStore: Send + Sync {
         offset: usize,
     ) -> Result<(Vec<JobRun>, usize)>;
     async fn cleanup(&self, job_id: Uuid, max_files: usize) -> Result<()>;
+    async fn read_manifest(&self, job_id: Uuid) -> Result<Option<JobManifest>>;
+    async fn update_manifest(&self, job_id: Uuid, run: &JobRun) -> Result<()>;
+    async fn rebuild_manifest(&self, job_id: Uuid) -> Result<JobManifest>;
 }
 ```
 
@@ -407,4 +411,68 @@ pub trait LogStore: Send + Sync {
 | `read_log` | Reads the full log or the last `tail` lines. Returns an empty string if the file is missing. |
 | `list_runs` | Lists all runs for a job with pagination; returns `(paginated_runs, total_count)`. |
 | `cleanup` | Removes the oldest runs beyond `max_files`, deleting both `.log` and `.meta.json` for each. |
+| `read_manifest` | Reads `manifest.json` for a job; returns `None` if the file is missing or cannot be parsed. |
+| `update_manifest` | Merges a completed run's data into the manifest, creating it if it does not exist. |
+| `rebuild_manifest` | Reconstructs the manifest by replaying all `.meta.json` files in the job's log directory. |
+
+---
+
+## 8. Per-Job Manifest Files
+
+**Source:** `acs/src/storage/logs.rs`, `acs/src/models/manifest.rs`
+
+Each job maintains a `manifest.json` file that aggregates cost, token usage, and runtime statistics across all of its runs.
+
+### Location
+
+```
+{data_dir}/logs/{job_id}/manifest.json
+```
+
+### When updated
+
+`update_manifest` is called automatically after every run completes, regardless of outcome (success, failure, timeout, or kill). It reads the existing manifest (creating a new one if absent), merges the completed run via `JobManifest::merge_run`, and writes the result back atomically using a temp-file-then-rename pattern.
+
+If the manifest is missing or corrupt, `rebuild_manifest` reconstructs it by iterating all `.meta.json` files in the job's log directory and replaying each run through `merge_run`. This makes the manifest self-healing — it can always be regenerated from the source-of-truth run files.
+
+### Data structures
+
+```rust
+pub struct JobManifest {
+    pub job_id: Uuid,
+    pub version: u32,
+    pub updated_at: DateTime<Utc>,
+    pub total_runs: u64,
+    pub total_cost_usd: f64,
+    pub total_duration_ms: u64,
+    pub daily_buckets: BTreeMap<String, TimeBucket>,   // key: "YYYY-MM-DD"
+    pub weekly_buckets: BTreeMap<String, TimeBucket>,  // key: "YYYY-WNN" (ISO week)
+    pub monthly_buckets: BTreeMap<String, TimeBucket>, // key: "YYYY-MM"
+}
+
+pub struct TimeBucket {
+    pub runs: u64,
+    pub cost_usd: f64,
+    pub duration_ms: u64,
+    pub num_turns: u64,
+    pub models: BTreeMap<String, ModelUsageBucket>,
+}
+
+pub struct ModelUsageBucket {
+    pub runs: u64,
+    pub cost_usd: f64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub cache_read_input_tokens: u64,
+}
+```
+
+`JobManifest` holds lifetime totals at the top level, plus three sets of time-bucketed `TimeBucket`s. Each `TimeBucket` further breaks down token usage per model via `ModelUsageBucket`. Runs that have no cost or usage data (e.g., non-Claude shell commands) are still counted in `runs` with zero values for the cost/token fields.
+
+All three struct types use `#[serde(default)]`, so older manifest files missing newer fields will deserialize safely with zero values rather than failing.
+
+### Atomic writes
+
+Manifests are written using the same temp-file-then-rename strategy as `jobs.json`: the updated manifest is serialized to `manifest.json.tmp`, then renamed over `manifest.json`. This ensures no partial writes are visible even if the process is interrupted mid-write.
 


### PR DESCRIPTION
## Summary

Implements a per-job manifest file system that aggregates cost, token usage, runtime, and execution statistics across all runs. This enables fast cost dashboards without scanning individual `.meta.json` files.

### Changes

| Area | File(s) | Description |
|------|---------|-------------|
| Model | `acs/src/models/manifest.rs` | `JobManifest`, `TimeBucket`, `ModelUsageBucket` structs with `merge_run()` aggregation |
| Model | `acs/src/models/mod.rs` | Re-export manifest types |
| Storage trait | `acs/src/storage/mod.rs` | `read_manifest`, `update_manifest`, `rebuild_manifest` on `LogStore` |
| Storage impl | `acs/src/storage/logs.rs` | `FsLogStore` implementation with atomic write-then-rename |
| Executor | `acs/src/daemon/executor.rs` | Call `update_manifest` after run completion |
| Daemon | `acs/src/daemon/mod.rs` | Wiring changes |
| Server | `acs/src/server/mod.rs` | Wiring changes |
| Tests | `acs/tests/api_tests.rs` | `LogStore` trait stubs for manifest methods |
| Docs | `docs/storage.md` | Manifest system documentation |

### Key Design Decisions
- **Atomic writes**: temp file then rename for crash safety
- **Self-healing**: `rebuild_manifest()` reconstructs from `.meta.json` files if manifest is missing/corrupt
- **Best-effort**: manifest update failure logs a warning but doesn't fail the run
- **Per-model breakdown**: tracks cost and tokens per model within daily buckets
- **Backward compat**: `#[serde(default)]` on all fields for forward migration

### Test Results
- 405 tests pass (383 unit + 13 API + 6 CLI + 3 scheduler)
- 14 new manifest-specific tests (7 model + 7 storage)

Closes #71

## Test plan
- [x] Unit tests for manifest aggregation, bucketing, serialization roundtrip
- [x] Unit tests for per-model token breakdown
- [x] Storage tests for read/update/rebuild manifest operations
- [x] Rebuild handles malformed `.meta.json` gracefully
- [x] Multiple runs across different days produce correct buckets
- [x] All existing tests continue to pass (405 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)