### PR TITLE
Fix timeout=0 validation and add pre/post hook UI to job form

### DIFF
--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,6 +1,1 @@
-[
-  {
-    "issue": 75,
-    "body": "## Implementation Plan (Approved)\n\n| # | Sub-task | Complexity | Depends on |\n|---|----------|------------|------------|\n| 1 | Fix timeout=0 validation and input handling (3 files, 4 locations) | Light | -- |\n| 2 | Add pre_hook/post_hook to TypeScript interfaces | Light | -- |\n| 3 | Add hook state management to useJobFormState | Light | 2 |\n| 4 | Add hook textarea fields to form UI | Standard | 3 |\n| 5 | Display hooks on job detail page | Light | 2 |\n\n**Execution order:** 1+2 parallel → 3+5 parallel → 4\n\n🤖 Autonomous nightly run"
-  }
-]
+[]

--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "issue": 75,
+    "body": "## Implementation Plan (Approved)\n\n| # | Sub-task | Complexity | Depends on |\n|---|----------|------------|------------|\n| 1 | Fix timeout=0 validation and input handling (3 files, 4 locations) | Light | -- |\n| 2 | Add pre_hook/post_hook to TypeScript interfaces | Light | -- |\n| 3 | Add hook state management to useJobFormState | Light | 2 |\n| 4 | Add hook textarea fields to form UI | Standard | 3 |\n| 5 | Display hooks on job detail page | Light | 2 |\n\n**Execution order:** 1+2 parallel → 3+5 parallel → 4\n\n🤖 Autonomous nightly run"
+  }
+]

--- a/electron/packages/frontend/src/components/jobs/FormSections.tsx
+++ b/electron/packages/frontend/src/components/jobs/FormSections.tsx
@@ -154,7 +154,7 @@ export function RuntimeFields({
           type="number"
           min={0}
           value={timeoutSecs}
-          onChange={(e) => setTimeoutSecs(parseInt(e.target.value, 10) || 3600)}
+          onChange={(e) => { const parsed = parseInt(e.target.value, 10); setTimeoutSecs(Number.isNaN(parsed) ? 0 : parsed); }}
           className={cn(errors.timeout && "border-destructive")}
         />
         <p className="text-xs text-muted-foreground">

--- a/electron/packages/frontend/src/components/jobs/FormSections.tsx
+++ b/electron/packages/frontend/src/components/jobs/FormSections.tsx
@@ -213,6 +213,49 @@ export function EnvVarsFields({
   );
 }
 
+/* -- Pre/Post Hook fields (no card wrapper) -- */
+export function PrePostHookFields({
+  preHook, setPreHook, postHook, setPostHook,
+}: {
+  preHook: string;
+  setPreHook: (v: string) => void;
+  postHook: string;
+  setPostHook: (v: string) => void;
+}) {
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="pre-hook">Pre-run Script</Label>
+        <Textarea
+          id="pre-hook"
+          value={preHook}
+          onChange={(e) => setPreHook(e.target.value)}
+          placeholder="echo 'starting...'"
+          rows={2}
+          className="font-mono"
+        />
+        <p className="text-xs text-muted-foreground">
+          Shell command to run before job execution. If it fails, the job is blocked.
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="post-hook">Post-run Script</Label>
+        <Textarea
+          id="post-hook"
+          value={postHook}
+          onChange={(e) => setPostHook(e.target.value)}
+          placeholder="echo 'done'"
+          rows={2}
+          className="font-mono"
+        />
+        <p className="text-xs text-muted-foreground">
+          Shell command to run after job execution. If it fails, the run is marked as CompletedWithWarnings.
+        </p>
+      </div>
+    </>
+  );
+}
+
 /* -- Reusable card wrapper -- */
 export function SectionCard({
   title, subtitle, children,

--- a/electron/packages/frontend/src/components/jobs/JobForm.tsx
+++ b/electron/packages/frontend/src/components/jobs/JobForm.tsx
@@ -26,7 +26,7 @@ export function JobForm({ job, title, onSubmit, submitLabel = "Save" }: JobFormP
       // If any validation errors are on advanced-tab fields, auto-switch
       // to that tab so the user can see them. We check the conditions
       // directly since state updates from validate() haven't flushed yet.
-      const hasAdvancedError = s.timeoutSecs < 1;
+      const hasAdvancedError = s.timeoutSecs < 0;
       if (hasAdvancedError && tab !== "advanced") {
         setTab("advanced");
       }

--- a/electron/packages/frontend/src/components/jobs/JobForm.tsx
+++ b/electron/packages/frontend/src/components/jobs/JobForm.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   FormTopBar, SectionCard,
-  JobDetailsFields, ScheduleFields, RuntimeFields, EnvVarsFields,
+  JobDetailsFields, ScheduleFields, RuntimeFields, EnvVarsFields, PrePostHookFields,
 } from "./FormSections";
 import { useJobFormState } from "./useJobFormState";
 import type { Job, NewJob } from "@/lib/types";
@@ -93,6 +93,14 @@ export function JobForm({ job, title, onSubmit, submitLabel = "Save" }: JobFormP
                 <EnvVarsFields
                   envVars={s.envVars} setEnvVars={s.setEnvVars}
                   logEnvironment={s.logEnvironment} setLogEnvironment={s.setLogEnvironment}
+                />
+              </SectionCard>
+              <SectionCard title="Hooks" subtitle="Pre and post execution scripts">
+                <PrePostHookFields
+                  preHook={s.preHook}
+                  setPreHook={s.setPreHook}
+                  postHook={s.postHook}
+                  setPostHook={s.setPostHook}
                 />
               </SectionCard>
             </div>

--- a/electron/packages/frontend/src/components/jobs/useJobFormState.ts
+++ b/electron/packages/frontend/src/components/jobs/useJobFormState.ts
@@ -52,7 +52,7 @@ export function useJobFormState(job?: Job | null) {
     if (!schedule.trim()) newErrors.schedule = "Schedule is required";
     const cronErr = validateCron(schedule);
     if (cronErr) newErrors.schedule = cronErr;
-    if (timeoutSecs < 1) newErrors.timeout = "Timeout must be at least 1 second";
+    if (timeoutSecs < 0) newErrors.timeout = "Timeout must not be negative";
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };

--- a/electron/packages/frontend/src/components/jobs/useJobFormState.ts
+++ b/electron/packages/frontend/src/components/jobs/useJobFormState.ts
@@ -24,6 +24,8 @@ export function useJobFormState(job?: Job | null) {
     job?.allow_concurrent ?? false
   );
   const [enabled, setEnabled] = useState(job?.enabled ?? true);
+  const [preHook, setPreHook] = useState(job?.pre_hook ?? "");
+  const [postHook, setPostHook] = useState(job?.post_hook ?? "");
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -41,6 +43,8 @@ export function useJobFormState(job?: Job | null) {
       setLogEnvironment(job.log_environment);
       setAllowConcurrent(job.allow_concurrent ?? false);
       setEnabled(job.enabled);
+      setPreHook(job.pre_hook ?? "");
+      setPostHook(job.post_hook ?? "");
     }
   }, [job]);
 
@@ -73,6 +77,8 @@ export function useJobFormState(job?: Job | null) {
     if (timezone) data.timezone = timezone;
     if (workingDir) data.working_dir = workingDir;
     if (Object.keys(envVars).length > 0) data.env_vars = envVars;
+    if (preHook.trim()) data.pre_hook = preHook.trim();
+    if (postHook.trim()) data.post_hook = postHook.trim();
     return data;
   };
 
@@ -80,7 +86,9 @@ export function useJobFormState(job?: Job | null) {
     job?.working_dir ||
     job?.log_environment ||
     (job?.env_vars && Object.keys(job.env_vars).length > 0) ||
-    (job && job.timeout_secs !== 3600)
+    (job && job.timeout_secs !== 3600) ||
+    job?.pre_hook ||
+    job?.post_hook
   );
 
   return {
@@ -95,6 +103,8 @@ export function useJobFormState(job?: Job | null) {
     logEnvironment, setLogEnvironment,
     allowConcurrent, setAllowConcurrent,
     enabled, setEnabled,
+    preHook, setPreHook,
+    postHook, setPostHook,
     errors: visibleErrors,
     submitting, setSubmitting,
     validate, buildData,

--- a/electron/packages/frontend/src/lib/types.ts
+++ b/electron/packages/frontend/src/lib/types.ts
@@ -10,6 +10,8 @@ export interface Job {
   timeout_secs: number;
   log_environment: boolean;
   allow_concurrent: boolean;
+  pre_hook: string | null;
+  post_hook: string | null;
   created_at: string;
   updated_at: string;
   last_run_at: string | null;
@@ -28,6 +30,8 @@ export interface NewJob {
   timeout_secs?: number;
   log_environment?: boolean;
   allow_concurrent?: boolean;
+  pre_hook?: string;
+  post_hook?: string;
 }
 
 export interface JobUpdate {
@@ -41,6 +45,8 @@ export interface JobUpdate {
   timeout_secs?: number;
   log_environment?: boolean;
   allow_concurrent?: boolean;
+  pre_hook?: string | null;
+  post_hook?: string | null;
 }
 
 export interface JobRun {

--- a/electron/packages/frontend/src/routes/JobDetailPage.tsx
+++ b/electron/packages/frontend/src/routes/JobDetailPage.tsx
@@ -360,6 +360,26 @@ export function JobDetailPage() {
                 <span className="text-sm">{formatDate(job.next_run_at)}</span>
               </div>
             )}
+            {job.pre_hook && (
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Pre-hook
+                </span>
+                <code className="font-mono text-sm bg-muted px-2 py-1 rounded truncate" title={job.pre_hook}>
+                  {job.pre_hook}
+                </code>
+              </div>
+            )}
+            {job.post_hook && (
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Post-hook
+                </span>
+                <code className="font-mono text-sm bg-muted px-2 py-1 rounded truncate" title={job.post_hook}>
+                  {job.post_hook}
+                </code>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Fix timeout field rejecting 0 (backend treats 0 as "no timeout / use daemon default") by correcting validation, input parsing, and error-tab logic
- Add pre_hook and post_hook textarea fields to the job form Advanced tab, with full state management and API integration
- Display configured hooks on the job detail page Configuration card

Relates to #75

## Changes
| File | Change |
|------|--------|
| `electron/packages/frontend/src/lib/types.ts` | Add `pre_hook` and `post_hook` to Job, NewJob, JobUpdate interfaces |
| `electron/packages/frontend/src/components/jobs/useJobFormState.ts` | Fix timeout validation (`< 1` → `< 0`), add hook state, useEffect sync, buildData() inclusion, hasAdvancedFields |
| `electron/packages/frontend/src/components/jobs/FormSections.tsx` | Fix parseInt fallback for timeout=0, add PrePostHookFields component |
| `electron/packages/frontend/src/components/jobs/JobForm.tsx` | Fix hasAdvancedError check, import and render PrePostHookFields in Advanced tab |
| `electron/packages/frontend/src/routes/JobDetailPage.tsx` | Display pre_hook and post_hook in Configuration card when set |

## AI Suggested Testing Plan
- [ ] Create a new job with timeout set to 0 — verify it saves without validation error and API receives `timeout_secs: 0`
- [ ] Edit an existing job, change timeout to 0, save — verify the value persists
- [ ] Create a job with pre-hook and post-hook scripts — verify they appear in the API payload
- [ ] Edit a job that has hooks — verify the textareas load with existing values
- [ ] Create a job with empty hooks — verify hooks are omitted from the payload (not sent as empty strings)
- [ ] View a job with hooks configured — verify the Configuration card shows Pre-hook and Post-hook entries
- [ ] View a job without hooks — verify no hook entries appear in the Configuration card

## Ticket
#75 — https://github.com/Commit0x/agent-cron-scheduler/issues/75

---
Generated by the starterpack orchestrator.