### PR TITLE
#98: Extract cost data during ghost recovery and shutdown fallback

### DIFF
--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,6 +1,1 @@
-[
-  {
-    "issue": 98,
-    "body": "## Approved Implementation Plan\n\n### Sub-task 1: Make `CostSummary` and `extract_cost_from_log` visible (light)\n- Change visibility to `pub(crate)` in `executor.rs` for `CostSummary` (struct + fields) and `extract_cost_from_log`\n- File: `acs/src/daemon/executor.rs`\n\n### Sub-task 2A: Extract cost during ghost run recovery (light)\n- Read log file via `log_store.read_log()` and call `extract_cost_from_log()` before marking orphaned runs as Killed\n- File: `acs/src/daemon/mod.rs`\n\n### Sub-task 2B: Extract cost during graceful shutdown fallback (light)\n- Read log file and extract cost instead of copying existing (null) fields\n- File: `acs/src/daemon/mod.rs`\n\n### Sub-task 3: Add/update tests (standard)\n- Update ghost recovery test to verify cost extraction\n- Add test for empty log (cost stays None)\n- File: `acs/src/daemon/mod.rs` (test module)\n\n### Dependencies\n`1 → [2A, 2B] → 3`\n\n### Note on dispatch loop path\nThe executor already extracts cost when handling `KillReason::Concurrent` (executor.rs:820-833). If the executor doesn't complete (child process not killed — issue #99), the run falls through to ghost recovery or shutdown fallback, which are addressed by sub-tasks 2A and 2B."
-  }
-]
+[]

--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "issue": 98,
+    "body": "## Approved Implementation Plan\n\n### Sub-task 1: Make `CostSummary` and `extract_cost_from_log` visible (light)\n- Change visibility to `pub(crate)` in `executor.rs` for `CostSummary` (struct + fields) and `extract_cost_from_log`\n- File: `acs/src/daemon/executor.rs`\n\n### Sub-task 2A: Extract cost during ghost run recovery (light)\n- Read log file via `log_store.read_log()` and call `extract_cost_from_log()` before marking orphaned runs as Killed\n- File: `acs/src/daemon/mod.rs`\n\n### Sub-task 2B: Extract cost during graceful shutdown fallback (light)\n- Read log file and extract cost instead of copying existing (null) fields\n- File: `acs/src/daemon/mod.rs`\n\n### Sub-task 3: Add/update tests (standard)\n- Update ghost recovery test to verify cost extraction\n- Add test for empty log (cost stays None)\n- File: `acs/src/daemon/mod.rs` (test module)\n\n### Dependencies\n`1 → [2A, 2B] → 3`\n\n### Note on dispatch loop path\nThe executor already extracts cost when handling `KillReason::Concurrent` (executor.rs:820-833). If the executor doesn't complete (child process not killed — issue #99), the run falls through to ghost recovery or shutdown fallback, which are addressed by sub-tasks 2A and 2B."
+  }
+]

--- a/acs/Cargo.lock
+++ b/acs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-cron-scheduler"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/acs/src/daemon/executor.rs
+++ b/acs/src/daemon/executor.rs
@@ -107,12 +107,12 @@ async fn run_hook(
 ///
 /// All fields represent aggregates summed across all Claude CLI invocations in the log,
 /// not a single invocation.
-struct CostSummary {
-    total_cost_usd: Option<f64>,
-    duration_ms: Option<u64>,
-    num_turns: Option<u32>,
-    model: Option<String>,
-    usage: Option<serde_json::Value>,
+pub(crate) struct CostSummary {
+    pub(crate) total_cost_usd: Option<f64>,
+    pub(crate) duration_ms: Option<u64>,
+    pub(crate) num_turns: Option<u32>,
+    pub(crate) model: Option<String>,
+    pub(crate) usage: Option<serde_json::Value>,
 }
 
 /// Extract cost data from a Claude CLI NDJSON log.
@@ -133,7 +133,7 @@ struct CostSummary {
 ///
 /// Non-NDJSON lines are silently skipped. As a performance optimisation, `serde_json::from_str`
 /// is only called on lines that contain the substring `"type"`.
-fn extract_cost_from_log(log_content: &[u8]) -> CostSummary {
+pub(crate) fn extract_cost_from_log(log_content: &[u8]) -> CostSummary {
     let mut summary = CostSummary {
         total_cost_usd: None,
         duration_ms: None,

--- a/acs/src/daemon/mod.rs
+++ b/acs/src/daemon/mod.rs
@@ -19,7 +19,7 @@ use tracing;
 use uuid::Uuid;
 
 use crate::daemon::events::JobEvent;
-use crate::daemon::executor::{Executor, KillReason, RunHandle};
+use crate::daemon::executor::{extract_cost_from_log, Executor, KillReason, RunHandle};
 use crate::daemon::scheduler::Scheduler;
 use crate::models::{DaemonConfig, RunStatus};
 use crate::server::{self, AppState};
@@ -500,6 +500,8 @@ pub async fn graceful_shutdown(
 
         for run in runs_list {
             if run.run_id == *run_id && run.status == RunStatus::Running {
+                let raw = log_store.read_log(*job_id, *run_id, None).await.unwrap_or_default();
+                let cost = extract_cost_from_log(raw.as_bytes());
                 let killed_run = crate::models::JobRun {
                     run_id: run.run_id,
                     job_id: run.job_id,
@@ -510,11 +512,11 @@ pub async fn graceful_shutdown(
                     log_size_bytes: run.log_size_bytes,
                     error: Some("Daemon shutting down".to_string()),
                     trigger_params: run.trigger_params.clone(),
-                    total_cost_usd: run.total_cost_usd,
-                    duration_ms: run.duration_ms,
-                    num_turns: run.num_turns,
-                    model: run.model.clone(),
-                    usage: run.usage.clone(),
+                    total_cost_usd: cost.total_cost_usd,
+                    duration_ms: cost.duration_ms,
+                    num_turns: cost.num_turns,
+                    model: cost.model,
+                    usage: cost.usage,
                 };
                 if let Err(e) = log_store.update_run(&killed_run).await {
                     tracing::error!("Failed to mark run {} as Killed: {}", run_id, e);
@@ -828,6 +830,16 @@ pub async fn start_daemon(
             Ok((runs, _total)) => {
                 for mut run in runs {
                     if run.status == crate::models::RunStatus::Running {
+                        let raw = log_store
+                            .read_log(job.id, run.run_id, None)
+                            .await
+                            .unwrap_or_default();
+                        let cost = extract_cost_from_log(raw.as_bytes());
+                        run.total_cost_usd = cost.total_cost_usd;
+                        run.duration_ms = cost.duration_ms;
+                        run.num_turns = cost.num_turns;
+                        run.model = cost.model;
+                        run.usage = cost.usage;
                         run.status = crate::models::RunStatus::Killed;
                         run.exit_code = Some(-1);
                         run.finished_at = Some(chrono::Utc::now());

--- a/acs/src/daemon/mod.rs
+++ b/acs/src/daemon/mod.rs
@@ -500,7 +500,10 @@ pub async fn graceful_shutdown(
 
         for run in runs_list {
             if run.run_id == *run_id && run.status == RunStatus::Running {
-                let raw = log_store.read_log(*job_id, *run_id, None).await.unwrap_or_default();
+                let raw = log_store
+                    .read_log(*job_id, *run_id, None)
+                    .await
+                    .unwrap_or_default();
                 let cost = extract_cost_from_log(raw.as_bytes());
                 let killed_run = crate::models::JobRun {
                     run_id: run.run_id,

--- a/acs/src/daemon/mod.rs
+++ b/acs/src/daemon/mod.rs
@@ -1496,6 +1496,13 @@ mod tests {
         };
         let all_jobs = vec![fake_job];
 
+        // Write NDJSON cost data to the log store for the orphaned run
+        let ndjson = b"{\"type\":\"system\",\"subtype\":\"init\",\"model\":\"claude-sonnet-4-20250514\"}\n{\"type\":\"result\",\"subtype\":\"success\",\"total_cost_usd\":0.0342,\"duration_ms\":5000,\"num_turns\":3,\"usage\":{\"input_tokens\":1000,\"output_tokens\":500}}\n";
+        log_store
+            .append_log(job_id, run_id, ndjson)
+            .await
+            .expect("append_log should succeed");
+
         // Execute the same ghost run recovery logic as run_daemon
         for job in &all_jobs {
             let (runs, _total) = log_store
@@ -1504,6 +1511,16 @@ mod tests {
                 .expect("list_runs should succeed");
             for mut run in runs {
                 if run.status == RunStatus::Running {
+                    let raw = log_store
+                        .read_log(job.id, run.run_id, None)
+                        .await
+                        .unwrap_or_default();
+                    let cost = extract_cost_from_log(raw.as_bytes());
+                    run.total_cost_usd = cost.total_cost_usd;
+                    run.duration_ms = cost.duration_ms;
+                    run.num_turns = cost.num_turns;
+                    run.model = cost.model;
+                    run.usage = cost.usage;
                     run.status = RunStatus::Killed;
                     run.exit_code = Some(-1);
                     run.finished_at = Some(Utc::now());
@@ -1542,6 +1559,165 @@ mod tests {
             recovered.error.as_deref(),
             Some("Orphaned run — process not found on daemon restart"),
             "Orphaned run should have the correct error message"
+        );
+        assert_eq!(
+            recovered.total_cost_usd,
+            Some(0.0342),
+            "Orphaned run should have cost extracted from log"
+        );
+        assert_eq!(
+            recovered.model.as_deref(),
+            Some("claude-sonnet-4-20250514"),
+            "Orphaned run should have model extracted from log"
+        );
+        assert_eq!(
+            recovered.duration_ms,
+            Some(5000),
+            "Orphaned run should have duration_ms extracted from log"
+        );
+        assert_eq!(
+            recovered.num_turns,
+            Some(3),
+            "Orphaned run should have num_turns extracted from log"
+        );
+        assert!(
+            recovered.usage.is_some(),
+            "Orphaned run should have usage extracted from log"
+        );
+    }
+
+    // =======================================================================
+    // 5b-2. Ghost run recovery — no log data leaves cost fields as None
+    // =======================================================================
+    #[tokio::test]
+    async fn test_ghost_run_recovery_no_log_data() {
+        use crate::models::Job;
+
+        let log_store = Arc::new(InMemoryLogStore::new());
+
+        let job_id = Uuid::now_v7();
+        let run_id = Uuid::now_v7();
+
+        // Simulate an orphaned run with no associated log data
+        let orphaned_run = crate::models::JobRun {
+            run_id,
+            job_id,
+            started_at: Utc::now(),
+            finished_at: None,
+            status: RunStatus::Running,
+            exit_code: None,
+            log_size_bytes: 0,
+            error: None,
+            trigger_params: None,
+            total_cost_usd: None,
+            duration_ms: None,
+            num_turns: None,
+            model: None,
+            usage: None,
+        };
+        log_store.create_run(&orphaned_run).await.unwrap();
+
+        // Build a minimal Job list (no log data written)
+        let fake_job = Job {
+            id: job_id,
+            name: "ghost-no-log-test-job".to_string(),
+            schedule: "* * * * *".to_string(),
+            execution: crate::models::ExecutionType::ShellCommand("echo hi".to_string()),
+            enabled: true,
+            timezone: None,
+            working_dir: None,
+            env_vars: None,
+            timeout_secs: 0,
+            log_environment: false,
+            allow_concurrent: false,
+            schedule_mode: crate::models::ScheduleMode::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            last_run_at: None,
+            last_exit_code: None,
+            pre_hook: None,
+            post_hook: None,
+            next_run_at: None,
+        };
+        let all_jobs = vec![fake_job];
+
+        // Execute the same ghost run recovery logic as run_daemon
+        for job in &all_jobs {
+            let (runs, _total) = log_store
+                .list_runs(job.id, 50, 0)
+                .await
+                .expect("list_runs should succeed");
+            for mut run in runs {
+                if run.status == RunStatus::Running {
+                    let raw = log_store
+                        .read_log(job.id, run.run_id, None)
+                        .await
+                        .unwrap_or_default();
+                    let cost = extract_cost_from_log(raw.as_bytes());
+                    run.total_cost_usd = cost.total_cost_usd;
+                    run.duration_ms = cost.duration_ms;
+                    run.num_turns = cost.num_turns;
+                    run.model = cost.model;
+                    run.usage = cost.usage;
+                    run.status = RunStatus::Killed;
+                    run.exit_code = Some(-1);
+                    run.finished_at = Some(Utc::now());
+                    run.error =
+                        Some("Orphaned run — process not found on daemon restart".to_string());
+                    log_store
+                        .update_run(&run)
+                        .await
+                        .expect("update_run should succeed");
+                }
+            }
+        }
+
+        // Verify recovery — status/exit_code/error set correctly
+        let runs = log_store.runs.read().await;
+        let recovered = runs
+            .iter()
+            .find(|r| r.run_id == run_id)
+            .expect("run should exist");
+
+        assert_eq!(
+            recovered.status,
+            RunStatus::Killed,
+            "Orphaned run should be marked as Killed"
+        );
+        assert_eq!(
+            recovered.exit_code,
+            Some(-1),
+            "Orphaned run should have exit_code -1"
+        );
+        assert!(
+            recovered.finished_at.is_some(),
+            "Orphaned run should have a finished_at timestamp"
+        );
+        assert_eq!(
+            recovered.error.as_deref(),
+            Some("Orphaned run — process not found on daemon restart"),
+            "Orphaned run should have the correct error message"
+        );
+        // Cost fields should all be None when no log data exists
+        assert!(
+            recovered.total_cost_usd.is_none(),
+            "total_cost_usd should be None when no log data"
+        );
+        assert!(
+            recovered.model.is_none(),
+            "model should be None when no log data"
+        );
+        assert!(
+            recovered.duration_ms.is_none(),
+            "duration_ms should be None when no log data"
+        );
+        assert!(
+            recovered.num_turns.is_none(),
+            "num_turns should be None when no log data"
+        );
+        assert!(
+            recovered.usage.is_none(),
+            "usage should be None when no log data"
         );
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,6 +187,8 @@ The `start_daemon()` function in `daemon::mod.rs` orchestrates startup:
 9.  cleanup_orphaned_logs() -- Remove log dirs for deleted jobs
 9a. Ghost run recovery      -- Scans all jobs for runs stuck in `Running`
                                 status from a previous daemon session.
+                                Reads the run's log file to extract any
+                                accumulated cost/usage data before marking.
                                 Marks them as `Killed` with exit_code `-1`
                                 and error 'Orphaned run — process not found
                                 on daemon restart'.
@@ -316,6 +318,7 @@ Triggered by Ctrl+C, SIGTERM (Unix), or `POST /api/shutdown`:
       - Send () on kill_tx         -- Signal task to stop
       - Await join_handle with 30s timeout
    c. For each in-flight run:
+      - Reads the run's log file to extract cost data before updating
       - Update JobRun to Killed status with finished_at and error message
    d. PidFile::release()           -- Remove agentcronsystem.pid
    e. PortFile::remove()           -- Remove agentcronsystem.port


### PR DESCRIPTION
## Summary
- Fix cost data being permanently lost when runs are killed outside the executor (ghost run recovery on daemon restart and graceful shutdown fallback)
- Read log files and call `extract_cost_from_log()` before marking orphaned/timed-out runs as Killed, so cost fields (`total_cost_usd`, `usage`, `duration_ms`, `num_turns`, `model`) are populated from whatever NDJSON data exists
- Closes #98

## Changes
| File | Change |
|------|--------|
| `acs/src/daemon/executor.rs` | Make `CostSummary` and `extract_cost_from_log` `pub(crate)` for use in `mod.rs` |
| `acs/src/daemon/mod.rs` | Add cost extraction from log files in ghost run recovery (daemon startup) |
| `acs/src/daemon/mod.rs` | Add cost extraction from log files in graceful shutdown Step 4 fallback |
| `acs/src/daemon/mod.rs` | Update ghost recovery tests to verify cost extraction; add empty-log test |
| `docs/architecture.md` | Mention cost extraction in ghost recovery and shutdown descriptions |

## AI Suggested Testing Plan
- [ ] Start a long-running job, force-kill the daemon, restart — verify the orphaned run's record has cost data populated from the log file
- [ ] Start a long-running job, trigger graceful shutdown while it's running, wait for the 30s timeout — verify the Killed record has cost data
- [ ] Start a job with no output, force-kill, restart — verify cost fields are `None` (graceful degradation)
- [ ] Run `cargo test --lib -- test_ghost_run_recovery` — all 3 tests pass

## Ticket
#98 — https://github.com/Jtonna/agent-cron-scheduler/issues/98

---
Generated by the starterpack orchestrator.