### PR TITLE
#107: Dashboard Page

### DIFF
--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,6 +1,1 @@
-[
-  {
-    "issue": 107,
-    "body": "## Implementation Plan\n\n**11 sub-tasks across 4 waves:**\n\nWave 1: ST-1 ANSI utility, ST-2 Data hooks (5), ST-6 ChatInput, ST-7 QuickActions\nWave 2: ST-3 Hook tests, ST-4 Footer, ST-5 SystemLogs+LogViewer, ST-8 WidgetCarousel+Charts, ST-10 RecentRuns\nWave 3: ST-9 HeroSection\nWave 4: ST-11 MonitoringPage composition\n\n26 new/modified files under `electron/packages/frontend-v2/src/`.\n\nAll human gates auto-approved (autonomous nightly mode)."
-  }
-]
+[]

--- a/.github/comment-queue.json
+++ b/.github/comment-queue.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "issue": 107,
+    "body": "## Implementation Plan\n\n**11 sub-tasks across 4 waves:**\n\nWave 1: ST-1 ANSI utility, ST-2 Data hooks (5), ST-6 ChatInput, ST-7 QuickActions\nWave 2: ST-3 Hook tests, ST-4 Footer, ST-5 SystemLogs+LogViewer, ST-8 WidgetCarousel+Charts, ST-10 RecentRuns\nWave 3: ST-9 HeroSection\nWave 4: ST-11 MonitoringPage composition\n\n26 new/modified files under `electron/packages/frontend-v2/src/`.\n\nAll human gates auto-approved (autonomous nightly mode)."
+  }
+]

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cd electron/packages/frontend && npm run dev
 
 The dev server proxies `/api/*` and `/health` to `http://127.0.0.1:8377` via rewrites in `next.config.ts`. The backend includes CORS middleware so direct cross-origin requests also work.
 
-A new frontend project at `electron/packages/frontend-v2/` contains the redesigned frontend with theme system, component library, and layout shell with navigation (issues #105, #106). Run `npm test` from that directory to execute the Vitest test suite.
+A new frontend project at `electron/packages/frontend-v2/` contains the redesigned frontend with theme system, component library, layout shell with navigation, and dashboard page (issues #105, #106, #107). Run `npm test` from that directory to execute the Vitest test suite.
 
 ### Testing
 
@@ -185,7 +185,7 @@ acs/                     # Rust project root
 electron/                # Electron app and frontend
   packages/
     frontend/            # Next.js interactive dashboard (independent)
-    frontend-v2/         # Next.js v2 — redesigned frontend (theme, components, layout shell)
+    frontend-v2/         # Next.js v2 — redesigned frontend (theme, components, layout shell, dashboard)
 docs/                    # Documentation
 ```
 

--- a/electron/packages/frontend-v2/src/components/dashboard/ChatInput.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/ChatInput.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
+
+export function ChatInput() {
+  return (
+    <div className="flex items-center gap-2 p-4">
+      <div className="flex-1 flex items-center gap-2 bg-card border border-border rounded-full px-4 py-3 shadow-sm focus-within:ring-1 focus-within:ring-primary/40">
+        <input
+          type="text"
+          placeholder="Ask your agent assistant..."
+          className="flex-1 bg-transparent text-foreground placeholder-muted-foreground outline-none text-sm"
+          disabled
+          readOnly
+        />
+      </div>
+      <button
+        type="button"
+        disabled
+        className="inline-flex items-center justify-center size-10 bg-primary text-primary-foreground rounded-full disabled:opacity-50 disabled:cursor-not-allowed hover:bg-primary/90 transition-colors"
+        aria-label="Send message"
+      >
+        <PaperAirplaneIcon className="size-5" />
+      </button>
+    </div>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/Footer.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/Footer.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { HealthResponse } from "@/lib/types";
+import { formatUptime } from "@/lib/format";
+
+interface FooterProps {
+  health: HealthResponse | null;
+}
+
+export function Footer({ health }: FooterProps) {
+  return (
+    <footer className="fixed bottom-0 left-0 right-0 z-40 border-t border-border/40 bg-card px-6 py-2">
+      <div className="flex items-center gap-3 text-[11px] font-mono text-muted-foreground">
+        {/* Status dot */}
+        <span className="flex items-center gap-1.5" aria-label="system status">
+          <span
+            className={[
+              "inline-block size-1.5 rounded-full shrink-0",
+              health?.status === "ok"
+                ? "bg-success animate-pulse"
+                : "bg-destructive",
+            ].join(" ")}
+            data-testid="status-dot"
+          />
+          <span>{health?.status === "ok" ? "ok" : health ? health.status : "—"}</span>
+        </span>
+
+        <span className="text-border/60">·</span>
+
+        {/* Uptime */}
+        <span>
+          {health != null
+            ? `up ${formatUptime(health.uptime_seconds)}`
+            : "up —"}
+        </span>
+
+        <span className="text-border/60">·</span>
+
+        {/* Active / Total jobs */}
+        <span>
+          {health != null
+            ? `${health.active_jobs} / ${health.total_jobs} jobs active`
+            : "— / — jobs active"}
+        </span>
+
+        <span className="text-border/60">·</span>
+
+        {/* Version */}
+        <span>v{health?.version ?? "—"}</span>
+
+        <span className="text-border/60">·</span>
+
+        {/* Data directory */}
+        <span className="truncate max-w-[320px]" title={health?.data_dir}>
+          {health?.data_dir ?? "—"}
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/HeroSection.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/HeroSection.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { GlobalCostSummaryResponse, Job } from "@/lib/types";
+import { ChatInput } from "./ChatInput";
+import { QuickActions } from "./QuickActions";
+import { WidgetCarousel } from "./WidgetCarousel";
+
+interface HeroSectionProps {
+  summary: GlobalCostSummaryResponse | null;
+  jobs: Job[];
+  scrollToLogs?: () => void;
+}
+
+export function HeroSection({ summary, jobs, scrollToLogs }: HeroSectionProps) {
+  return (
+    <div data-testid="hero-section" className="grid grid-cols-1 lg:grid-cols-[55fr_45fr] gap-6">
+      {/* Left column */}
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">Dashboard</h1>
+          <p className="text-sm text-muted-foreground mt-1">Monitor your jobs and system health</p>
+        </div>
+        <ChatInput />
+        <QuickActions scrollToLogs={scrollToLogs} />
+      </div>
+
+      {/* Right column */}
+      <div>
+        <WidgetCarousel summary={summary} jobs={jobs} />
+      </div>
+    </div>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/LogViewer.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/LogViewer.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+import React, {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+  useCallback,
+} from "react";
+import {
+  MagnifyingGlassIcon,
+  XMarkIcon,
+  ArrowDownIcon,
+  ArrowsPointingOutIcon,
+  ChevronRightIcon,
+  PaintBrushIcon,
+} from "@heroicons/react/24/outline";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+import { ansiToHtml, stripAnsi } from "@/lib/ansi";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface LogViewerProps {
+  content: string;
+  loading?: boolean;
+  error?: string | null;
+  live?: boolean;
+  className?: string;
+  maxHeight?: string;
+}
+
+interface LogLine {
+  number: number;
+  text: string;
+  parsedJson?: Record<string, unknown> | unknown[];
+}
+
+function highlightMatches(text: string, query: string): React.ReactNode {
+  if (!query) return text;
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(${escaped})`, "gi");
+  const parts = text.split(regex);
+  if (parts.length === 1) return text;
+  return parts.map((part, i) =>
+    regex.test(part) ? (
+      <mark
+        key={i}
+        className="bg-yellow-200 dark:bg-yellow-900/50 text-inherit rounded-sm px-0.5"
+      >
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+}
+
+/**
+ * Tries to parse a string as JSON. Returns the parsed value only if it's
+ * an object or array (not a primitive).
+ */
+function tryParseJson(
+  text: string
+): Record<string, unknown> | unknown[] | undefined {
+  const trimmed = text.trim();
+  // Quick guard: only attempt parse if the line starts with { or [
+  if (trimmed.length === 0 || (trimmed[0] !== "{" && trimmed[0] !== "[")) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed !== null && typeof parsed === "object") {
+      return parsed as Record<string, unknown> | unknown[];
+    }
+  } catch {
+    // not JSON
+  }
+  return undefined;
+}
+
+/**
+ * Truncates raw JSON text for the collapsed preview.
+ */
+function jsonPreviewText(raw: string, maxLen = 100): string {
+  const trimmed = raw.trim();
+  if (trimmed.length <= maxLen) return trimmed;
+  const suffix = trimmed[0] === "[" ? " ...]" : " ...}";
+  return trimmed.slice(0, maxLen - suffix.length) + suffix;
+}
+
+/**
+ * Lightweight recursive JSON syntax highlighter.
+ */
+function JsonSyntaxHighlight({
+  value,
+  indent = 0,
+}: {
+  value: unknown;
+  indent?: number;
+}) {
+  const pad = "  ".repeat(indent);
+  const padInner = "  ".repeat(indent + 1);
+
+  if (value === null) {
+    return <span className="text-muted-foreground italic">null</span>;
+  }
+  if (typeof value === "boolean") {
+    return (
+      <span className="text-amber-600 dark:text-amber-400">
+        {String(value)}
+      </span>
+    );
+  }
+  if (typeof value === "number") {
+    return (
+      <span className="text-blue-600 dark:text-blue-400">{String(value)}</span>
+    );
+  }
+  if (typeof value === "string") {
+    return (
+      <span className="text-emerald-600 dark:text-emerald-400">
+        &quot;{value}&quot;
+      </span>
+    );
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className="text-muted-foreground">{"[]"}</span>;
+    }
+    return (
+      <>
+        <span className="text-muted-foreground">{"["}</span>
+        {"\n"}
+        {value.map((item, i) => (
+          <React.Fragment key={i}>
+            {padInner}
+            <JsonSyntaxHighlight value={item} indent={indent + 1} />
+            {i < value.length - 1 && (
+              <span className="text-muted-foreground">,</span>
+            )}
+            {"\n"}
+          </React.Fragment>
+        ))}
+        {pad}
+        <span className="text-muted-foreground">{"]"}</span>
+      </>
+    );
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+      return <span className="text-muted-foreground">{"{}"}</span>;
+    }
+    return (
+      <>
+        <span className="text-muted-foreground">{"{"}</span>
+        {"\n"}
+        {entries.map(([key, val], i) => (
+          <React.Fragment key={key}>
+            {padInner}
+            <span className="text-primary">&quot;{key}&quot;</span>
+            <span className="text-muted-foreground">: </span>
+            <JsonSyntaxHighlight value={val} indent={indent + 1} />
+            {i < entries.length - 1 && (
+              <span className="text-muted-foreground">,</span>
+            )}
+            {"\n"}
+          </React.Fragment>
+        ))}
+        {pad}
+        <span className="text-muted-foreground">{"}"}</span>
+      </>
+    );
+  }
+  // Fallback for any other type
+  return <span>{String(value)}</span>;
+}
+
+export const LogViewer = React.memo(function LogViewer({
+  content,
+  loading = false,
+  error = null,
+  live = false,
+  className = "",
+  maxHeight = "calc(100vh - 300px)",
+}: LogViewerProps) {
+  const [search, setSearch] = useState("");
+  const [showAllLines, setShowAllLines] = useState(false);
+  const [wordWrap, setWordWrap] = useState(true);
+  const [userScrolled, setUserScrolled] = useState(false);
+  const [ansiColors, setAnsiColors] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("log-ansi-colors") !== "false";
+    }
+    return true;
+  });
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Stores scroll state captured before a render so we can restore it after
+  const prevScrollRef = useRef<{
+    scrollTop: number;
+    scrollHeight: number;
+  } | null>(null);
+  // Tracks when a scroll is being set programmatically so handleScroll can ignore it
+  const isProgrammaticScroll = useRef(false);
+  // Tracks whether new content has arrived while user is scrolled up
+  const hasNewContent = useRef(false);
+  // Force re-render when hasNewContent changes
+  const [, setNewContentIndicator] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem("log-ansi-colors", String(ansiColors));
+  }, [ansiColors]);
+
+  // Track which JSON lines are expanded
+  const [expandedJsonLines, setExpandedJsonLines] = useState<Set<number>>(
+    () => new Set()
+  );
+
+  const toggleJsonLine = useCallback((lineNumber: number) => {
+    setExpandedJsonLines((prev) => {
+      const next = new Set(prev);
+      if (next.has(lineNumber)) {
+        next.delete(lineNumber);
+      } else {
+        next.add(lineNumber);
+      }
+      return next;
+    });
+  }, []);
+
+  // Parse lines, detecting JSON
+  const allLines: LogLine[] = useMemo(() => {
+    if (!content) return [];
+    const raw = content.split("\n");
+    // Remove trailing empty line from split
+    if (raw.length > 0 && raw[raw.length - 1] === "") {
+      raw.pop();
+    }
+    return raw.map((text, i) => {
+      const parsedJson = tryParseJson(text);
+      return { number: i + 1, text, parsedJson };
+    });
+  }, [content]);
+
+  // Filter lines by search
+  const query = search.trim().toLowerCase();
+
+  const matchingLineNumbers = useMemo(() => {
+    if (!query) return new Set<number>();
+    const set = new Set<number>();
+    for (const line of allLines) {
+      if (stripAnsi(line.text).toLowerCase().includes(query)) {
+        set.add(line.number);
+      }
+    }
+    return set;
+  }, [allLines, query]);
+
+  const displayLines = useMemo(() => {
+    if (!query || showAllLines) return allLines;
+    return allLines.filter((line) => matchingLineNumbers.has(line.number));
+  }, [allLines, query, showAllLines, matchingLineNumbers]);
+
+  const matchCount = matchingLineNumbers.size;
+  const totalLines = allLines.length;
+  const gutterWidth = Math.max(String(totalLines).length, 3);
+
+  // Scroll tracking
+  const handleScroll = useCallback(() => {
+    // Ignore scroll events fired by programmatic scroll assignments
+    if (isProgrammaticScroll.current) return;
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    setUserScrolled(!atBottom);
+    // Clear new content indicator when user scrolls to bottom
+    if (atBottom) {
+      hasNewContent.current = false;
+      setNewContentIndicator(false);
+    }
+  }, []);
+
+  // Capture scroll position before every render so we can restore it after
+  // if the user has scrolled up (prevents viewport shift from layout reflows).
+  if (scrollContainerRef.current && userScrolled) {
+    const el = scrollContainerRef.current;
+    prevScrollRef.current = {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+    };
+  } else {
+    prevScrollRef.current = null;
+  }
+
+  // After render: restore scroll position when user has scrolled up so that
+  // appended content (or content mutations) don't shift the visible viewport.
+  useLayoutEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el || !userScrolled || !prevScrollRef.current) return;
+    const { scrollTop: prevScrollTop, scrollHeight: prevScrollHeight } =
+      prevScrollRef.current;
+    const scrollHeightDelta = el.scrollHeight - prevScrollHeight;
+    // Only adjust if layout actually changed (guards against no-op renders)
+    if (scrollHeightDelta !== 0) {
+      el.scrollTop = prevScrollTop + scrollHeightDelta;
+    }
+  });
+
+  // Auto-scroll to bottom for live logs (instant, no animation to fight new content)
+  useEffect(() => {
+    if (live && !userScrolled) {
+      const el = scrollContainerRef.current;
+      if (el) {
+        isProgrammaticScroll.current = true;
+        el.scrollTop = el.scrollHeight;
+        requestAnimationFrame(() => {
+          isProgrammaticScroll.current = false;
+        });
+      }
+    }
+  }, [content, live, userScrolled]);
+
+  // Track new content arrival while user is scrolled up
+  useEffect(() => {
+    if (userScrolled && content) {
+      hasNewContent.current = true;
+      setNewContentIndicator(true);
+    }
+  }, [content, userScrolled]);
+
+  const jumpToBottom = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (el) {
+      isProgrammaticScroll.current = true;
+      el.scrollTop = el.scrollHeight;
+      requestAnimationFrame(() => {
+        isProgrammaticScroll.current = false;
+      });
+    }
+    setUserScrolled(false);
+    hasNewContent.current = false;
+    setNewContentIndicator(false);
+  }, []);
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className={`flex items-center justify-center py-8 ${className}`}>
+        <ArrowPathIcon className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div
+        className={`rounded-lg border border-destructive/50 bg-destructive/10 p-4 ${className}`}
+      >
+        <p className="text-sm text-destructive">Error loading log: {error}</p>
+      </div>
+    );
+  }
+
+  // Empty content
+  if (!content) {
+    return (
+      <div
+        className={`rounded-lg border bg-muted/50 p-8 text-center ${className}`}
+      >
+        <p className="text-sm text-muted-foreground">No output.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`flex flex-col rounded-lg border bg-[var(--code-bg)] ${className}`}
+    >
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b bg-muted/30">
+        {/* Search */}
+        <div className="relative flex-1 max-w-sm">
+          <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search logs..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-7 pl-8 pr-8 text-xs"
+          />
+          {search.length > 0 && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-0.5 top-1/2 -translate-y-1/2 h-6 w-6"
+              onClick={() => setSearch("")}
+              aria-label="Clear search"
+            >
+              <XMarkIcon className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+
+        {/* Stats */}
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {query
+            ? `${matchCount} / ${totalLines} matches`
+            : `${totalLines} lines`}
+        </span>
+
+        {/* Show all / matching toggle (when searching) */}
+        {query && (
+          <Button
+            variant={showAllLines ? "secondary" : "outline"}
+            size="sm"
+            className="h-7 text-xs px-2"
+            onClick={() => setShowAllLines((v) => !v)}
+          >
+            {showAllLines ? "All" : "Matches"}
+          </Button>
+        )}
+
+        {/* Wrap toggle */}
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={wordWrap ? "secondary" : "outline"}
+                size="icon"
+                className="h-7 w-7"
+                onClick={() => setWordWrap((v) => !v)}
+                aria-label="Toggle word wrap"
+              >
+                <ArrowsPointingOutIcon className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {wordWrap ? "Disable word wrap" : "Enable word wrap"}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        {/* ANSI color toggle */}
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={ansiColors ? "secondary" : "outline"}
+                size="icon"
+                className="h-7 w-7"
+                onClick={() => setAnsiColors((v) => !v)}
+                aria-label="Toggle ANSI colors"
+              >
+                <PaintBrushIcon className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {ansiColors ? "Disable ANSI colors" : "Enable ANSI colors"}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        {/* Live badge */}
+        {live && (
+          <Badge variant="running" className="animate-pulse text-xs h-5">
+            Live
+          </Badge>
+        )}
+      </div>
+
+      {/* Log content */}
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="overflow-auto"
+        style={{ maxHeight }}
+      >
+        <div className="font-mono text-xs leading-relaxed bg-[var(--code-bg)] min-w-0">
+          {displayLines.map((line) => {
+            const isMatch = query && matchingLineNumbers.has(line.number);
+            const isDimmed = query && showAllLines && !isMatch;
+            const isJson = !!line.parsedJson;
+            const isExpanded = isJson && expandedJsonLines.has(line.number);
+
+            return (
+              <div
+                key={line.number}
+                className={`flex hover:bg-accent/50 border-b border-border/30 group ${
+                  isDimmed ? "opacity-40" : ""
+                } ${isMatch ? "bg-yellow-50/50 dark:bg-yellow-900/10" : ""}`}
+              >
+                {/* Line number gutter */}
+                <span
+                  className="select-none text-muted-foreground/60 text-right px-3 py-0.5 border-r border-border/40 shrink-0 tabular-nums"
+                  style={{ minWidth: `${gutterWidth + 2}ch` }}
+                >
+                  {line.number}
+                </span>
+                {/* Line content */}
+                {isJson ? (
+                  <div className="px-3 py-0.5 min-w-0 flex-1">
+                    {/* Collapsed JSON preview / trigger */}
+                    <button
+                      type="button"
+                      className="flex items-center gap-1.5 w-full text-left cursor-pointer hover:bg-accent/30 rounded -mx-1 px-1"
+                      onClick={() => toggleJsonLine(line.number)}
+                      aria-expanded={isExpanded}
+                    >
+                      <ChevronRightIcon
+                        className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150 ${
+                          isExpanded ? "rotate-90" : ""
+                        }`}
+                      />
+                      <span
+                        className={`truncate ${
+                          wordWrap
+                            ? "whitespace-pre-wrap break-words"
+                            : "whitespace-pre"
+                        }`}
+                      >
+                        {query && isMatch
+                          ? highlightMatches(
+                              jsonPreviewText(line.text),
+                              search.trim()
+                            )
+                          : jsonPreviewText(line.text)}
+                      </span>
+                      <Badge
+                        variant="outline"
+                        className="ml-1.5 shrink-0 text-[10px] px-1.5 py-0 h-4 font-mono opacity-60"
+                      >
+                        JSON
+                      </Badge>
+                    </button>
+                    {/* Expanded JSON view */}
+                    {isExpanded && (
+                      <div className="mt-1 ml-5 border-l-2 border-border/60 pl-3 pb-1">
+                        <pre className="text-[12px] leading-relaxed whitespace-pre-wrap break-words">
+                          <JsonSyntaxHighlight value={line.parsedJson} />
+                        </pre>
+                      </div>
+                    )}
+                  </div>
+                ) : ansiColors && !query ? (
+                  <span
+                    className={`px-3 py-0.5 min-w-0 ${
+                      wordWrap
+                        ? "whitespace-pre-wrap break-words"
+                        : "whitespace-pre"
+                    }`}
+                    dangerouslySetInnerHTML={{
+                      __html: ansiToHtml(line.text) || "\u00A0",
+                    }}
+                  />
+                ) : (
+                  <span
+                    className={`px-3 py-0.5 min-w-0 ${
+                      wordWrap
+                        ? "whitespace-pre-wrap break-words"
+                        : "whitespace-pre"
+                    }`}
+                  >
+                    {(() => {
+                      const displayText = stripAnsi(line.text);
+                      return query && isMatch
+                        ? highlightMatches(displayText, search.trim())
+                        : displayText || "\u00A0";
+                    })()}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Jump to bottom */}
+      {userScrolled && (
+        <div className="flex justify-center py-1 border-t bg-muted/30">
+          <Button
+            variant={hasNewContent.current ? "default" : "ghost"}
+            size="sm"
+            className={`h-6 text-xs gap-1 ${
+              hasNewContent.current ? "animate-pulse font-semibold" : ""
+            }`}
+            onClick={jumpToBottom}
+          >
+            <ArrowDownIcon className="h-3 w-3" />
+            {hasNewContent.current ? "New logs ↓" : "Jump to bottom"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/electron/packages/frontend-v2/src/components/dashboard/QuickActions.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useNavigate } from "react-router-dom";
+import {
+  QueueListIcon,
+  PlusCircleIcon,
+  ArrowPathIcon,
+  CommandLineIcon,
+} from "@heroicons/react/24/outline";
+import { api } from "@/lib/api";
+
+export function QuickActions({ scrollToLogs }: { scrollToLogs?: () => void }) {
+  const navigate = useNavigate();
+
+  const handleRestart = async () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to restart the server?"
+    );
+    if (!confirmed) return;
+    await api.restart();
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => navigate("/jobs")}
+        className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition-colors hover:bg-muted"
+      >
+        <QueueListIcon className="size-4 text-muted-foreground" />
+        Jobs
+      </button>
+
+      <button
+        type="button"
+        onClick={() => navigate("/jobs/create")}
+        className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition-colors hover:bg-muted"
+      >
+        <PlusCircleIcon className="size-4 text-muted-foreground" />
+        Create Job
+      </button>
+
+      <button
+        type="button"
+        onClick={handleRestart}
+        className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition-colors hover:bg-muted"
+      >
+        <ArrowPathIcon className="size-4 text-muted-foreground" />
+        Restart
+      </button>
+
+      <button
+        type="button"
+        onClick={() => scrollToLogs?.()}
+        className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition-colors hover:bg-muted"
+      >
+        <CommandLineIcon className="size-4 text-muted-foreground" />
+        System Logs
+      </button>
+    </div>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/RecentRuns.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/RecentRuns.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Badge, statusToBadgeVariant } from "@/components/ui/badge";
+import { formatDate, formatCost } from "@/lib/format";
+import { useRecentRuns } from "@/hooks/useRecentRuns";
+import type { RecentRunEntry } from "@/lib/types";
+
+interface RecentRunsProps {
+  onRefresh?: () => void;
+}
+
+function formatDuration(durationMs: number | null | undefined): string {
+  if (durationMs === null || durationMs === undefined) return "--";
+  const totalSeconds = Math.floor(durationMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+interface RunCardProps {
+  run: RecentRunEntry;
+}
+
+function RunCard({ run }: RunCardProps) {
+  const badgeVariant = statusToBadgeVariant(run.status, run.exit_code);
+
+  const exitCodeClass =
+    run.exit_code === null
+      ? "text-muted-foreground"
+      : run.exit_code === 0
+        ? "text-success"
+        : "text-error";
+
+  return (
+    <div className="rounded-xl bg-card p-5 shadow-[var(--shadow-card)] border border-border/50 flex flex-col gap-3">
+      {/* Header: job name + status badge */}
+      <div className="flex items-start justify-between gap-2 min-w-0">
+        <span className="font-semibold text-sm truncate flex-1" title={run.job_name}>
+          {run.job_name}
+        </span>
+        <Badge variant={badgeVariant} className="shrink-0">
+          {run.status}
+        </Badge>
+      </div>
+
+      {/* 2x2 info grid */}
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
+        <div>
+          <dt className="text-muted-foreground">Started</dt>
+          <dd className="text-foreground">{formatDate(run.started_at)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Duration</dt>
+          <dd className="text-foreground">{formatDuration(run.duration_ms)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Exit code</dt>
+          <dd className={exitCodeClass}>
+            {run.exit_code === null ? "--" : run.exit_code}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Cost</dt>
+          <dd className="text-foreground">{formatCost(run.total_cost_usd)}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div
+      className="rounded-xl bg-card p-5 shadow-[var(--shadow-card)] border border-border/50 flex flex-col gap-3 animate-pulse"
+      aria-hidden="true"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="h-4 w-2/3 rounded bg-muted" />
+        <div className="h-5 w-16 rounded-full bg-muted" />
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-1">
+            <div className="h-3 w-12 rounded bg-muted" />
+            <div className="h-3 w-16 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function RecentRuns({ onRefresh: _onRefresh }: RecentRunsProps = {}) {
+  const { runs, loading, error } = useRecentRuns(12);
+
+  return (
+    <section aria-labelledby="recent-runs-heading">
+      <h2
+        id="recent-runs-heading"
+        className="text-lg font-semibold mb-4"
+      >
+        Recent Runs
+      </h2>
+
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+
+      {loading && !error && (
+        <div
+          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4"
+          data-testid="recent-runs-skeleton"
+        >
+          {Array.from({ length: 8 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      )}
+
+      {!loading && !error && runs.length === 0 && (
+        <p className="text-sm text-muted-foreground">No recent runs</p>
+      )}
+
+      {!loading && !error && runs.length > 0 && (
+        <div
+          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4"
+          data-testid="recent-runs-grid"
+        >
+          {runs.map((run) => (
+            <RunCard key={run.run_id} run={run} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/SystemLogs.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/SystemLogs.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+import { useSystemLogs } from "@/hooks/useSystemLogs";
+import { LogViewer } from "@/components/dashboard/LogViewer";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export function SystemLogs() {
+  const [tail, setTail] = useState("200");
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const { logs, loading, error, refresh } = useSystemLogs(Number(tail));
+
+  // Auto-refresh polling
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const timer = setInterval(refresh, 3000);
+    return () => clearInterval(timer);
+  }, [autoRefresh, refresh]);
+
+  return (
+    <section
+      id="system-logs"
+      aria-label="System Logs"
+      className="flex flex-col gap-3 flex-1 min-h-0"
+    >
+      {/* Card container */}
+      <div className="rounded-xl bg-card shadow-[var(--shadow-card)] flex flex-col flex-1 min-h-0 overflow-hidden">
+        {/* Header + controls */}
+        <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4 border-b border-border">
+          <h2 className="text-lg font-semibold" id="system-logs">
+            System Logs
+          </h2>
+          <div className="flex flex-wrap items-center gap-3">
+            <Tabs value={tail} onValueChange={setTail}>
+              <TabsList>
+                <TabsTrigger value="100">100</TabsTrigger>
+                <TabsTrigger value="200">200</TabsTrigger>
+                <TabsTrigger value="500">500</TabsTrigger>
+                <TabsTrigger value="1000">1K</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="logs-auto-refresh"
+                checked={autoRefresh}
+                onCheckedChange={setAutoRefresh}
+              />
+              <Label htmlFor="logs-auto-refresh">Auto-refresh</Label>
+            </div>
+          </div>
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div className="mx-5 mt-3 rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        {/* Log viewer */}
+        <div className="flex-1 min-h-0">
+          {loading && !logs ? (
+            <div className="flex items-center justify-center py-12">
+              <ArrowPathIcon className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <LogViewer
+              content={logs || ""}
+              loading={false}
+              error={null}
+              live={autoRefresh}
+              maxHeight="100%"
+              className="border-0 rounded-none"
+            />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/WidgetCarousel.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/WidgetCarousel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GlobalCostSummaryResponse, Job } from "@/lib/types";
+import { DonutChart } from "./charts/DonutChart";
+import { BarChart } from "./charts/BarChart";
+import { NextRunTimer } from "./charts/NextRunTimer";
+
+interface WidgetCarouselProps {
+  summary: GlobalCostSummaryResponse | null;
+  jobs: Job[];
+}
+
+const SLIDE_COUNT = 3;
+const AUTO_ADVANCE_MS = 5000;
+
+export function WidgetCarousel({ summary, jobs }: WidgetCarouselProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isPausedRef = useRef(false);
+
+  const startTimer = useCallback(() => {
+    // Clear any existing timer first
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    intervalRef.current = setInterval(() => {
+      if (!isPausedRef.current) {
+        setActiveIndex((prev) => (prev + 1) % SLIDE_COUNT);
+      }
+    }, AUTO_ADVANCE_MS);
+  }, []);
+
+  useEffect(() => {
+    startTimer();
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [startTimer]);
+
+  const handleMouseEnter = () => {
+    isPausedRef.current = true;
+  };
+
+  const handleMouseLeave = () => {
+    isPausedRef.current = false;
+  };
+
+  const handleDotClick = (index: number) => {
+    setActiveIndex(index);
+    // Reset timer on manual navigation
+    startTimer();
+  };
+
+  // Loading state
+  if (!summary) {
+    return (
+      <div
+        className="rounded-xl bg-card shadow-[var(--shadow-card)] p-5 min-h-[280px] flex items-center justify-center"
+        data-testid="widget-carousel-loading"
+      >
+        <div className="flex flex-col items-center gap-2 text-muted-foreground">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          <span className="text-sm">Loading widgets...</span>
+        </div>
+      </div>
+    );
+  }
+
+  const slides = [
+    <DonutChart key="donut" topJobs={summary.top_jobs} />,
+    <BarChart key="bar" dailyTrend={summary.daily_trend} />,
+    <NextRunTimer key="timer" jobs={jobs} />,
+  ];
+
+  return (
+    <div
+      className="rounded-xl bg-card shadow-[var(--shadow-card)] p-5 min-h-[280px] flex flex-col"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      data-testid="widget-carousel"
+    >
+      {/* Slide content */}
+      <div className="flex-1 flex items-center justify-center" data-testid="carousel-slide">
+        {slides[activeIndex]}
+      </div>
+
+      {/* Dot indicators */}
+      <div className="flex items-center justify-center gap-2 pt-3" data-testid="carousel-dots">
+        {Array.from({ length: SLIDE_COUNT }).map((_, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => handleDotClick(i)}
+            aria-label={`Go to slide ${i + 1}`}
+            className={`h-2 rounded-full transition-all ${
+              i === activeIndex
+                ? "w-5 bg-primary"
+                : "w-2 bg-muted-foreground/30 hover:bg-muted-foreground/50"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/__tests__/Footer.test.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/__tests__/Footer.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "next-themes";
+import { AccentThemeProvider } from "@/hooks/use-accent-theme";
+import { Footer } from "../Footer";
+import type { HealthResponse } from "@/lib/types";
+
+const sampleHealth: HealthResponse = {
+  status: "ok",
+  uptime_seconds: 3725, // 1h 2m 5s → should render "1h 2m"
+  active_jobs: 3,
+  total_jobs: 15,
+  version: "1.4.2",
+  data_dir: "/home/user/.local/share/acs",
+};
+
+function renderFooter(health: HealthResponse | null) {
+  return render(
+    <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
+      <AccentThemeProvider>
+        <Footer health={health} />
+      </AccentThemeProvider>
+    </ThemeProvider>
+  );
+}
+
+describe("Footer", () => {
+  it("renders all health fields when health is provided", () => {
+    renderFooter(sampleHealth);
+
+    // Uptime: 3725s = 1h 2m (days=0, hours=1, minutes=2)
+    expect(screen.getByText(/up 1h 2m/)).toBeInTheDocument();
+
+    // Active / total jobs
+    expect(screen.getByText("3 / 15 jobs active")).toBeInTheDocument();
+
+    // Version
+    expect(screen.getByText("v1.4.2")).toBeInTheDocument();
+
+    // Data directory
+    expect(screen.getByText("/home/user/.local/share/acs")).toBeInTheDocument();
+  });
+
+  it("shows status dot with bg-success class when status is ok", () => {
+    renderFooter(sampleHealth);
+    const dot = screen.getByTestId("status-dot");
+    expect(dot).toHaveClass("bg-success");
+    expect(dot).not.toHaveClass("bg-destructive");
+  });
+
+  it("shows status dot with bg-destructive class when status is not ok", () => {
+    const errorHealth: HealthResponse = {
+      ...sampleHealth,
+      status: "error",
+    };
+    renderFooter(errorHealth);
+    const dot = screen.getByTestId("status-dot");
+    expect(dot).toHaveClass("bg-destructive");
+    expect(dot).not.toHaveClass("bg-success");
+  });
+
+  it("handles null health gracefully (loading state)", () => {
+    renderFooter(null);
+
+    // Status should show em-dash placeholder
+    expect(screen.getByTestId("status-dot")).toBeInTheDocument();
+
+    // Uptime placeholder
+    expect(screen.getByText("up —")).toBeInTheDocument();
+
+    // Jobs placeholder
+    expect(screen.getByText("— / — jobs active")).toBeInTheDocument();
+
+    // Version placeholder
+    expect(screen.getByText("v—")).toBeInTheDocument();
+  });
+
+  it("renders the footer element", () => {
+    renderFooter(sampleHealth);
+    expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+  });
+});

--- a/electron/packages/frontend-v2/src/components/dashboard/__tests__/HeroSection.test.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/__tests__/HeroSection.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider } from "next-themes";
+import { AccentThemeProvider } from "@/hooks/use-accent-theme";
+import { HeroSection } from "../HeroSection";
+import type { GlobalCostSummaryResponse, Job } from "@/lib/types";
+
+// Mock child components with simple div placeholders
+vi.mock("../ChatInput", () => ({
+  ChatInput: () => <div data-testid="chat-input">ChatInput</div>,
+}));
+
+vi.mock("../QuickActions", () => ({
+  QuickActions: ({ scrollToLogs }: { scrollToLogs?: () => void }) => (
+    <div data-testid="quick-actions" data-has-scroll={!!scrollToLogs}>
+      QuickActions
+    </div>
+  ),
+}));
+
+vi.mock("../WidgetCarousel", () => ({
+  WidgetCarousel: () => <div data-testid="widget-carousel">WidgetCarousel</div>,
+}));
+
+const mockSummary: GlobalCostSummaryResponse = {
+  timeframe: "30d",
+  today_usd: 1.5,
+  week_usd: 10.0,
+  month_usd: 42.0,
+  today_tokens: { input: 5000, output: 3000 },
+  top_jobs: [
+    { job_id: "1", job_name: "Job A", total_cost: 20, total_runs: 10 },
+  ],
+  daily_trend: [
+    { date: "2026-04-18", cost_usd: 3.0, input_tokens: 1000, output_tokens: 800 },
+  ],
+};
+
+const mockJobs: Job[] = [
+  {
+    id: "j1",
+    name: "Test Job",
+    schedule: "*/5 * * * *",
+    execution: { type: "ShellCommand", value: "echo hello" },
+    enabled: true,
+    timezone: null,
+    working_dir: null,
+    env_vars: null,
+    timeout_secs: 300,
+    log_environment: false,
+    allow_concurrent: false,
+    pre_hook: null,
+    post_hook: null,
+    pre_hook_script_type: null,
+    post_hook_script_type: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    last_run_at: null,
+    last_exit_code: null,
+    next_run_at: "2026-04-20T12:00:00Z",
+  },
+];
+
+function renderHeroSection(
+  summary: GlobalCostSummaryResponse | null = mockSummary,
+  jobs: Job[] = mockJobs,
+  scrollToLogs?: () => void
+) {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
+        <AccentThemeProvider>
+          <HeroSection summary={summary} jobs={jobs} scrollToLogs={scrollToLogs} />
+        </AccentThemeProvider>
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("HeroSection", () => {
+  it('renders heading "Dashboard"', () => {
+    renderHeroSection();
+    expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
+  });
+
+  it("renders subtitle text", () => {
+    renderHeroSection();
+    expect(screen.getByText("Monitor your jobs and system health")).toBeInTheDocument();
+  });
+
+  it("renders ChatInput mock", () => {
+    renderHeroSection();
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+  });
+
+  it("renders QuickActions mock", () => {
+    renderHeroSection();
+    expect(screen.getByTestId("quick-actions")).toBeInTheDocument();
+  });
+
+  it("renders WidgetCarousel mock", () => {
+    renderHeroSection();
+    expect(screen.getByTestId("widget-carousel")).toBeInTheDocument();
+  });
+
+  it("layout has correct grid classes", () => {
+    renderHeroSection();
+    const grid = screen.getByTestId("hero-section");
+    expect(grid).toHaveClass("grid");
+    expect(grid).toHaveClass("grid-cols-1");
+    expect(grid).toHaveClass("gap-6");
+  });
+});

--- a/electron/packages/frontend-v2/src/components/dashboard/__tests__/RecentRuns.test.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/__tests__/RecentRuns.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "next-themes";
+import { AccentThemeProvider } from "@/hooks/use-accent-theme";
+import { MemoryRouter } from "react-router-dom";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import type { RecentRunEntry } from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listRecentRuns: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { RecentRuns } from "../RecentRuns";
+
+const mockApi = api as { listRecentRuns: ReturnType<typeof vi.fn> };
+
+const sampleRuns: RecentRunEntry[] = [
+  {
+    run_id: "run-1",
+    job_id: "job-1",
+    job_name: "Daily Backup",
+    started_at: "2024-01-01T10:00:00Z",
+    finished_at: "2024-01-01T10:05:00Z",
+    status: "Completed",
+    exit_code: 0,
+    log_size_bytes: 1024,
+    error: null,
+    duration_ms: 83000,
+    total_cost_usd: 0.0042,
+    num_turns: null,
+    model: null,
+    usage: null,
+  },
+  {
+    run_id: "run-2",
+    job_id: "job-2",
+    job_name: "Weekly Report",
+    started_at: "2024-01-01T09:00:00Z",
+    finished_at: "2024-01-01T09:10:00Z",
+    status: "Failed",
+    exit_code: 1,
+    log_size_bytes: 512,
+    error: "Command failed",
+    duration_ms: 600000,
+    total_cost_usd: null,
+    num_turns: null,
+    model: null,
+    usage: null,
+  },
+  {
+    run_id: "run-3",
+    job_id: "job-3",
+    job_name: "Running Task",
+    started_at: "2024-01-02T08:00:00Z",
+    finished_at: null,
+    status: "Running",
+    exit_code: null,
+    log_size_bytes: 0,
+    error: null,
+    duration_ms: null,
+    total_cost_usd: null,
+    num_turns: null,
+    model: null,
+    usage: null,
+  },
+];
+
+function renderRecentRuns() {
+  return render(
+    <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
+      <AccentThemeProvider>
+        <MemoryRouter>
+          <RecentRuns />
+        </MemoryRouter>
+      </AccentThemeProvider>
+    </ThemeProvider>
+  );
+}
+
+describe("RecentRuns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton initially", () => {
+    // Keep the promise pending so loading remains true
+    mockApi.listRecentRuns.mockReturnValue(new Promise(() => {}));
+    renderRecentRuns();
+
+    expect(screen.getByTestId("recent-runs-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders run cards with correct data after loading", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: sampleRuns, limit: 12 });
+    renderRecentRuns();
+
+    // Wait for the grid to appear
+    const grid = await screen.findByTestId("recent-runs-grid");
+    expect(grid).toBeInTheDocument();
+
+    // Job names
+    expect(screen.getByText("Daily Backup")).toBeInTheDocument();
+    expect(screen.getByText("Weekly Report")).toBeInTheDocument();
+    expect(screen.getByText("Running Task")).toBeInTheDocument();
+
+    // Status badges
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("displays duration and cost for run-1", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: sampleRuns, limit: 12 });
+    renderRecentRuns();
+
+    await screen.findByTestId("recent-runs-grid");
+
+    // Duration: 83000ms = 1m 23s
+    expect(screen.getByText("1m 23s")).toBeInTheDocument();
+
+    // Cost: $0.0042
+    expect(screen.getByText("$0.0042")).toBeInTheDocument();
+  });
+
+  it("shows '--' for null cost and duration", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: sampleRuns, limit: 12 });
+    renderRecentRuns();
+
+    await screen.findByTestId("recent-runs-grid");
+
+    // run-2 and run-3 have null total_cost_usd — there should be at least one '--'
+    const dashes = screen.getAllByText("--");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no runs", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: [], limit: 12 });
+    renderRecentRuns();
+
+    expect(await screen.findByText("No recent runs")).toBeInTheDocument();
+    expect(screen.queryByTestId("recent-runs-grid")).not.toBeInTheDocument();
+  });
+
+  it("shows error message when API fails", async () => {
+    mockApi.listRecentRuns.mockRejectedValue(new Error("Network error"));
+    renderRecentRuns();
+
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Network error");
+  });
+
+  it("renders the section heading", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: sampleRuns, limit: 12 });
+    renderRecentRuns();
+
+    // Wait for loading to complete so no act() warnings fire
+    await screen.findByTestId("recent-runs-grid");
+    expect(screen.getByText("Recent Runs")).toBeInTheDocument();
+  });
+
+  it("grid has responsive column classes", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: sampleRuns, limit: 12 });
+    renderRecentRuns();
+
+    const grid = await screen.findByTestId("recent-runs-grid");
+    expect(grid).toHaveClass("grid-cols-1");
+    expect(grid).toHaveClass("sm:grid-cols-2");
+    expect(grid).toHaveClass("md:grid-cols-3");
+    expect(grid).toHaveClass("xl:grid-cols-4");
+  });
+
+  it("renders correct number of run cards", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: sampleRuns, limit: 12 });
+    renderRecentRuns();
+
+    await screen.findByTestId("recent-runs-grid");
+
+    // Each card has a job name — verify count via the presence of all 3
+    const jobNames = ["Daily Backup", "Weekly Report", "Running Task"];
+    jobNames.forEach((name) => {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    });
+  });
+});

--- a/electron/packages/frontend-v2/src/components/dashboard/__tests__/SystemLogs.test.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/__tests__/SystemLogs.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "next-themes";
+import { AccentThemeProvider } from "@/hooks/use-accent-theme";
+import { SystemLogs } from "../SystemLogs";
+
+// Mock the api module
+vi.mock("@/lib/api", () => ({
+  api: {
+    getSystemLogs: vi.fn(() => Promise.resolve("")),
+  },
+  getBaseUrl: vi.fn(() => "http://localhost:3000"),
+}));
+
+vi.mock("@/lib/connections", () => ({
+  getConnections: vi.fn(() => []),
+  getActiveConnectionId: vi.fn(() => null),
+  getActiveConnection: vi.fn(() => null),
+  setActiveConnectionId: vi.fn(),
+  deleteConnection: vi.fn(),
+}));
+
+import { api } from "@/lib/api";
+const mockGetSystemLogs = api.getSystemLogs as ReturnType<typeof vi.fn>;
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="light"
+      disableTransitionOnChange
+    >
+      <AccentThemeProvider>{ui}</AccentThemeProvider>
+    </ThemeProvider>
+  );
+}
+
+describe("SystemLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSystemLogs.mockResolvedValue("");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders with tail size selector tabs", async () => {
+    renderWithProviders(<SystemLogs />);
+
+    // Check for tail size tabs
+    expect(screen.getByRole("tab", { name: "100" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "200" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "500" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "1K" })).toBeInTheDocument();
+  });
+
+  it("renders auto-refresh toggle", async () => {
+    renderWithProviders(<SystemLogs />);
+
+    // The switch should render
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    // Label text
+    expect(screen.getByText("Auto-refresh")).toBeInTheDocument();
+  });
+
+  it("displays log content when loaded", async () => {
+    mockGetSystemLogs.mockResolvedValue(
+      "2024-01-01 INFO Starting server\n2024-01-01 INFO Listening on port 3000"
+    );
+
+    renderWithProviders(<SystemLogs />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Starting server/)
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Listening on port 3000/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading spinner initially", () => {
+    // Make the promise never resolve to keep loading state
+    mockGetSystemLogs.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<SystemLogs />);
+
+    // The loading spinner should be visible (ArrowPathIcon with animate-spin)
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("handles error state", async () => {
+    mockGetSystemLogs.mockRejectedValue(new Error("Connection refused"));
+
+    renderWithProviders(<SystemLogs />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connection refused")).toBeInTheDocument();
+    });
+  });
+
+  it("handles empty log content", async () => {
+    mockGetSystemLogs.mockResolvedValue("");
+
+    renderWithProviders(<SystemLogs />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No output.")).toBeInTheDocument();
+    });
+  });
+
+  it("renders the section heading", () => {
+    renderWithProviders(<SystemLogs />);
+
+    expect(screen.getByText("System Logs")).toBeInTheDocument();
+  });
+
+  it("has the system-logs id for scroll-to behavior", () => {
+    renderWithProviders(<SystemLogs />);
+
+    const section = document.getElementById("system-logs");
+    expect(section).toBeInTheDocument();
+  });
+});

--- a/electron/packages/frontend-v2/src/components/dashboard/__tests__/WidgetCarousel.test.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/__tests__/WidgetCarousel.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "next-themes";
+import { AccentThemeProvider } from "@/hooks/use-accent-theme";
+import { WidgetCarousel } from "../WidgetCarousel";
+import type { GlobalCostSummaryResponse, Job } from "@/lib/types";
+
+// Mock chart child components with simple placeholders
+vi.mock("../charts/DonutChart", () => ({
+  DonutChart: () => <div data-testid="donut-chart">DonutChart</div>,
+}));
+
+vi.mock("../charts/BarChart", () => ({
+  BarChart: () => <div data-testid="bar-chart">BarChart</div>,
+}));
+
+vi.mock("../charts/NextRunTimer", () => ({
+  NextRunTimer: () => <div data-testid="next-run-timer">NextRunTimer</div>,
+}));
+
+const mockSummary: GlobalCostSummaryResponse = {
+  timeframe: "30d",
+  today_usd: 1.5,
+  week_usd: 10.0,
+  month_usd: 42.0,
+  today_tokens: { input: 5000, output: 3000 },
+  top_jobs: [
+    { job_id: "1", job_name: "Job A", total_cost: 20, total_runs: 10 },
+    { job_id: "2", job_name: "Job B", total_cost: 15, total_runs: 8 },
+  ],
+  daily_trend: [
+    { date: "2026-04-18", cost_usd: 3.0, input_tokens: 1000, output_tokens: 800 },
+    { date: "2026-04-19", cost_usd: 5.0, input_tokens: 2000, output_tokens: 1500 },
+  ],
+};
+
+const mockJobs: Job[] = [
+  {
+    id: "j1",
+    name: "Test Job",
+    schedule: "*/5 * * * *",
+    execution: { type: "ShellCommand", value: "echo hello" },
+    enabled: true,
+    timezone: null,
+    working_dir: null,
+    env_vars: null,
+    timeout_secs: 300,
+    log_environment: false,
+    allow_concurrent: false,
+    pre_hook: null,
+    post_hook: null,
+    pre_hook_script_type: null,
+    post_hook_script_type: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    last_run_at: null,
+    last_exit_code: null,
+    next_run_at: "2026-04-20T12:00:00Z",
+  },
+];
+
+function renderCarousel(
+  summary: GlobalCostSummaryResponse | null = mockSummary,
+  jobs: Job[] = mockJobs
+) {
+  return render(
+    <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
+      <AccentThemeProvider>
+        <WidgetCarousel summary={summary} jobs={jobs} />
+      </AccentThemeProvider>
+    </ThemeProvider>
+  );
+}
+
+describe("WidgetCarousel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders 3 dot indicators", () => {
+    renderCarousel();
+    const dots = screen.getByTestId("carousel-dots");
+    const buttons = dots.querySelectorAll("button");
+    expect(buttons).toHaveLength(3);
+  });
+
+  it("renders the first slide (DonutChart) by default", () => {
+    renderCarousel();
+    expect(screen.getByTestId("donut-chart")).toBeInTheDocument();
+  });
+
+  it("shows all 3 slides when navigating via dots", async () => {
+    const user = userEvent.setup();
+    renderCarousel();
+
+    // Slide 1: DonutChart is already showing
+    expect(screen.getByTestId("donut-chart")).toBeInTheDocument();
+
+    // Click dot 2 -> BarChart
+    const dots = screen.getByTestId("carousel-dots").querySelectorAll("button");
+    await user.click(dots[1]);
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+
+    // Click dot 3 -> NextRunTimer
+    await user.click(dots[2]);
+    expect(screen.getByTestId("next-run-timer")).toBeInTheDocument();
+  });
+
+  it("auto-advances with fake timers", () => {
+    vi.useFakeTimers();
+
+    renderCarousel();
+
+    // Initially shows DonutChart
+    expect(screen.getByTestId("donut-chart")).toBeInTheDocument();
+
+    // Advance 5 seconds -> should move to BarChart
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+
+    // Advance another 5 seconds -> should move to NextRunTimer
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByTestId("next-run-timer")).toBeInTheDocument();
+
+    // Advance another 5 seconds -> should wrap back to DonutChart
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByTestId("donut-chart")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("handles null summary (loading state)", () => {
+    renderCarousel(null);
+    expect(screen.getByTestId("widget-carousel-loading")).toBeInTheDocument();
+    expect(screen.getByText("Loading widgets...")).toBeInTheDocument();
+  });
+});

--- a/electron/packages/frontend-v2/src/components/dashboard/charts/BarChart.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/charts/BarChart.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import type { GlobalDailyTrend } from "@/lib/types";
+import { formatCost } from "@/lib/format";
+
+interface BarChartProps {
+  dailyTrend: GlobalDailyTrend[];
+}
+
+/**
+ * Format a date string (YYYY-MM-DD) to a short day label (e.g. "Mon", "Tue").
+ * Falls back to the last 5 chars of the date string if parsing fails.
+ */
+function formatDayLabel(dateStr: string): string {
+  try {
+    const d = new Date(dateStr + "T00:00:00");
+    return d.toLocaleDateString("en-US", { weekday: "short" });
+  } catch {
+    return dateStr.slice(-5);
+  }
+}
+
+export function BarChart({ dailyTrend }: BarChartProps) {
+  if (!dailyTrend || dailyTrend.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No trend data available
+      </div>
+    );
+  }
+
+  const maxCost = Math.max(...dailyTrend.map((d) => d.cost_usd), 0.0001);
+
+  // SVG layout constants
+  const marginLeft = 48;
+  const marginRight = 8;
+  const marginTop = 12;
+  const marginBottom = 24;
+  const chartWidth = 260;
+  const chartHeight = 140;
+  const svgWidth = marginLeft + chartWidth + marginRight;
+  const svgHeight = marginTop + chartHeight + marginBottom;
+
+  const barCount = dailyTrend.length;
+  const barGap = 4;
+  const barWidth = Math.max(
+    4,
+    (chartWidth - barGap * (barCount - 1)) / barCount
+  );
+
+  // Y-axis ticks (3 ticks: 0, mid, max)
+  const yTicks = [0, maxCost / 2, maxCost];
+
+  return (
+    <div className="flex flex-col items-center">
+      <svg
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        className="h-[160px] w-full max-w-[320px]"
+        role="img"
+        aria-label="Daily cost trend bar chart"
+      >
+        {/* Y-axis labels and grid lines */}
+        {yTicks.map((tick, i) => {
+          const y = marginTop + chartHeight - (tick / maxCost) * chartHeight;
+          return (
+            <g key={i}>
+              <line
+                x1={marginLeft}
+                x2={marginLeft + chartWidth}
+                y1={y}
+                y2={y}
+                stroke="var(--border)"
+                strokeDasharray="3,3"
+              />
+              <text
+                x={marginLeft - 6}
+                y={y + 3}
+                textAnchor="end"
+                className="fill-muted-foreground text-[8px]"
+              >
+                {formatCost(tick)}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Bars */}
+        {dailyTrend.map((d, i) => {
+          const barHeight = (d.cost_usd / maxCost) * chartHeight;
+          const x = marginLeft + i * (barWidth + barGap);
+          const y = marginTop + chartHeight - barHeight;
+          return (
+            <g key={d.date}>
+              <rect
+                x={x}
+                y={y}
+                width={barWidth}
+                height={Math.max(barHeight, 1)}
+                rx={2}
+                fill="var(--chart-1)"
+              />
+              {/* X-axis label */}
+              <text
+                x={x + barWidth / 2}
+                y={marginTop + chartHeight + 14}
+                textAnchor="middle"
+                className="fill-muted-foreground text-[7px]"
+              >
+                {formatDayLabel(d.date)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/charts/DonutChart.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/charts/DonutChart.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import type { GlobalTopJob } from "@/lib/types";
+import { formatCost } from "@/lib/format";
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+interface DonutChartProps {
+  topJobs: GlobalTopJob[];
+}
+
+/**
+ * Compute the SVG arc path for a donut segment.
+ * Uses stroke-based arcs on a circle with given radius.
+ */
+function describeArc(
+  cx: number,
+  cy: number,
+  r: number,
+  startAngle: number,
+  endAngle: number
+): string {
+  // Clamp to avoid full-circle path issues
+  const sweep = Math.min(endAngle - startAngle, 359.999);
+  const startRad = ((startAngle - 90) * Math.PI) / 180;
+  const endRad = ((startAngle + sweep - 90) * Math.PI) / 180;
+
+  const x1 = cx + r * Math.cos(startRad);
+  const y1 = cy + r * Math.sin(startRad);
+  const x2 = cx + r * Math.cos(endRad);
+  const y2 = cy + r * Math.sin(endRad);
+
+  const largeArc = sweep > 180 ? 1 : 0;
+
+  return `M ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2}`;
+}
+
+export function DonutChart({ topJobs }: DonutChartProps) {
+  if (!topJobs || topJobs.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No cost data available
+      </div>
+    );
+  }
+
+  const totalCost = topJobs.reduce((sum, j) => sum + j.total_cost, 0);
+
+  // Build segments
+  const segments: { job: GlobalTopJob; startAngle: number; sweep: number; color: string }[] = [];
+  let currentAngle = 0;
+
+  topJobs.forEach((job, i) => {
+    const fraction = totalCost > 0 ? job.total_cost / totalCost : 0;
+    const sweep = fraction * 360;
+    segments.push({
+      job,
+      startAngle: currentAngle,
+      sweep,
+      color: CHART_COLORS[i % CHART_COLORS.length],
+    });
+    currentAngle += sweep;
+  });
+
+  const cx = 65;
+  const cy = 65;
+  const r = 50;
+  const strokeWidth = 18;
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <svg viewBox="0 0 130 130" className="h-[120px] w-[120px]">
+        {/* Background ring */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke="var(--muted)"
+          strokeWidth={strokeWidth}
+        />
+        {/* Segments */}
+        {segments.map((seg, i) => {
+          if (seg.sweep < 0.1) return null;
+          // For a single job that takes 100%, draw a near-full circle
+          const path = describeArc(cx, cy, r, seg.startAngle, seg.startAngle + seg.sweep);
+          return (
+            <path
+              key={seg.job.job_id || i}
+              d={path}
+              fill="none"
+              stroke={seg.color}
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+            />
+          );
+        })}
+        {/* Center text */}
+        <text
+          x={cx}
+          y={cy - 6}
+          textAnchor="middle"
+          className="fill-foreground text-[11px] font-semibold"
+        >
+          {formatCost(totalCost)}
+        </text>
+        <text
+          x={cx}
+          y={cy + 8}
+          textAnchor="middle"
+          className="fill-muted-foreground text-[8px]"
+        >
+          total
+        </text>
+      </svg>
+
+      {/* Legend */}
+      <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+        {segments.map((seg, i) => (
+          <div key={seg.job.job_id || i} className="flex items-center gap-1.5 text-[11px]">
+            <span
+              className="inline-block h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: seg.color }}
+            />
+            <span className="max-w-[100px] truncate text-foreground">
+              {seg.job.job_name}
+            </span>
+            <span className="text-muted-foreground">{formatCost(seg.job.total_cost)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/electron/packages/frontend-v2/src/components/dashboard/charts/NextRunTimer.tsx
+++ b/electron/packages/frontend-v2/src/components/dashboard/charts/NextRunTimer.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ClockIcon } from "@heroicons/react/24/outline";
+import type { Job } from "@/lib/types";
+
+interface NextRunTimerProps {
+  jobs: Job[];
+}
+
+interface NextRun {
+  jobName: string;
+  schedule: string;
+  targetTime: Date;
+}
+
+function findNextRun(jobs: Job[]): NextRun | null {
+  const now = new Date();
+  let soonest: NextRun | null = null;
+
+  for (const job of jobs) {
+    if (!job.next_run_at || !job.enabled) continue;
+    const target = new Date(job.next_run_at);
+    if (target <= now) continue;
+
+    if (!soonest || target < soonest.targetTime) {
+      soonest = {
+        jobName: job.name,
+        schedule: job.schedule,
+        targetTime: target,
+      };
+    }
+  }
+
+  return soonest;
+}
+
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return "00:00:00";
+
+  const totalSecs = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSecs / 3600);
+  const minutes = Math.floor((totalSecs % 3600) / 60);
+  const seconds = totalSecs % 60;
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+export function NextRunTimer({ jobs }: NextRunTimerProps) {
+  const [nextRun, setNextRun] = useState<NextRun | null>(() => findNextRun(jobs));
+  const [remaining, setRemaining] = useState<number>(0);
+
+  // Re-evaluate which job is next when the jobs list changes
+  useEffect(() => {
+    const run = findNextRun(jobs);
+    setNextRun(run);
+    if (run) {
+      setRemaining(run.targetTime.getTime() - Date.now());
+    }
+  }, [jobs]);
+
+  // Countdown interval
+  useEffect(() => {
+    if (!nextRun) return;
+
+    const tick = () => {
+      const diff = nextRun.targetTime.getTime() - Date.now();
+      setRemaining(Math.max(diff, 0));
+
+      // If countdown reached zero, re-evaluate
+      if (diff <= 0) {
+        const run = findNextRun(jobs);
+        setNextRun(run);
+      }
+    };
+
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [nextRun, jobs]);
+
+  if (!nextRun) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+        <ClockIcon className="size-8" />
+        <span className="text-sm">No scheduled runs</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3">
+      <ClockIcon className="size-8 text-primary" />
+      <div className="text-center">
+        <p className="text-sm font-medium text-foreground truncate max-w-[200px]">
+          {nextRun.jobName}
+        </p>
+        <p className="mt-1 font-mono text-2xl font-bold tabular-nums text-foreground">
+          {formatCountdown(remaining)}
+        </p>
+        <p className="mt-1 text-[11px] text-muted-foreground font-mono">
+          {nextRun.schedule}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/electron/packages/frontend-v2/src/hooks/__tests__/useGlobalCostSummary.test.ts
+++ b/electron/packages/frontend-v2/src/hooks/__tests__/useGlobalCostSummary.test.ts
@@ -1,0 +1,96 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getGlobalCostSummary: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useGlobalCostSummary } from "../useGlobalCostSummary";
+
+const mockApi = api as { getGlobalCostSummary: ReturnType<typeof vi.fn> };
+
+const mockSummary = {
+  timeframe: "30d",
+  today_usd: 0.42,
+  week_usd: 2.1,
+  month_usd: 8.75,
+  today_tokens: { input: 5000, output: 2000 },
+  top_jobs: [
+    { job_id: "job-1", job_name: "Daily Report", total_cost: 3.5, total_runs: 30 },
+  ],
+  daily_trend: [
+    { date: "2024-01-01", cost_usd: 0.3, input_tokens: 4000, output_tokens: 1500 },
+  ],
+};
+
+describe("useGlobalCostSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts with loading true", () => {
+    mockApi.getGlobalCostSummary.mockResolvedValue(mockSummary);
+    const { result } = renderHook(() => useGlobalCostSummary());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("returns summary on successful fetch", async () => {
+    mockApi.getGlobalCostSummary.mockResolvedValue(mockSummary);
+    const { result } = renderHook(() => useGlobalCostSummary());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.summary).toEqual(mockSummary);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error on API failure", async () => {
+    mockApi.getGlobalCostSummary.mockRejectedValue(new Error("Cost summary unavailable"));
+    const { result } = renderHook(() => useGlobalCostSummary());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Cost summary unavailable");
+    expect(result.current.summary).toBeNull();
+  });
+
+  it("clears summary on API failure", async () => {
+    // First load succeeds
+    mockApi.getGlobalCostSummary.mockResolvedValue(mockSummary);
+    const { result } = renderHook(() => useGlobalCostSummary());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.summary).toEqual(mockSummary);
+
+    // Then refresh fails
+    mockApi.getGlobalCostSummary.mockRejectedValue(new Error("Server error"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.summary).toBeNull();
+    expect(result.current.error).toBe("Server error");
+  });
+
+  it("refresh triggers re-fetch", async () => {
+    mockApi.getGlobalCostSummary.mockResolvedValue(mockSummary);
+    const { result } = renderHook(() => useGlobalCostSummary());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockApi.getGlobalCostSummary).toHaveBeenCalledTimes(1);
+
+    const updatedSummary = { ...mockSummary, today_usd: 0.99 };
+    mockApi.getGlobalCostSummary.mockResolvedValue(updatedSummary);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockApi.getGlobalCostSummary).toHaveBeenCalledTimes(2);
+    expect(result.current.summary).toEqual(updatedSummary);
+  });
+});

--- a/electron/packages/frontend-v2/src/hooks/__tests__/useHealth.test.ts
+++ b/electron/packages/frontend-v2/src/hooks/__tests__/useHealth.test.ts
@@ -1,0 +1,128 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    health: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useHealth } from "../useHealth";
+
+const mockApi = api as { health: ReturnType<typeof vi.fn> };
+
+const mockHealthData = {
+  status: "ok",
+  uptime_seconds: 120,
+  active_jobs: 2,
+  total_jobs: 5,
+  version: "1.0.0",
+  data_dir: "/data",
+};
+
+describe("useHealth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts with loading true", () => {
+    mockApi.health.mockResolvedValue(mockHealthData);
+    const { result } = renderHook(() => useHealth());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("returns health data on successful fetch", async () => {
+    mockApi.health.mockResolvedValue(mockHealthData);
+    const { result } = renderHook(() => useHealth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.health).toEqual(mockHealthData);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error on API failure", async () => {
+    mockApi.health.mockRejectedValue(new Error("Network error"));
+    const { result } = renderHook(() => useHealth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Network error");
+    expect(result.current.health).toBeNull();
+  });
+
+  it("refresh triggers re-fetch", async () => {
+    mockApi.health.mockResolvedValue(mockHealthData);
+    const { result } = renderHook(() => useHealth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockApi.health).toHaveBeenCalledTimes(1);
+
+    const updatedHealth = { ...mockHealthData, uptime_seconds: 200 };
+    mockApi.health.mockResolvedValue(updatedHealth);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockApi.health).toHaveBeenCalledTimes(2);
+    expect(result.current.health).toEqual(updatedHealth);
+  });
+
+  describe("interval polling", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("sets up interval polling", async () => {
+      mockApi.health.mockResolvedValue(mockHealthData);
+      renderHook(() => useHealth(1000));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockApi.health).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+
+      expect(mockApi.health).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+
+      expect(mockApi.health).toHaveBeenCalledTimes(3);
+    });
+
+    it("cleans up interval on unmount", async () => {
+      mockApi.health.mockResolvedValue(mockHealthData);
+      const { unmount } = renderHook(() => useHealth(1000));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockApi.health).toHaveBeenCalledTimes(1);
+
+      unmount();
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+        await Promise.resolve();
+      });
+
+      // After unmount, no additional calls should be made
+      expect(mockApi.health).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/electron/packages/frontend-v2/src/hooks/__tests__/useJobs.test.ts
+++ b/electron/packages/frontend-v2/src/hooks/__tests__/useJobs.test.ts
@@ -1,0 +1,149 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listJobs: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useJobs } from "../useJobs";
+
+const mockApi = api as { listJobs: ReturnType<typeof vi.fn> };
+
+const mockJobs = [
+  {
+    id: "job-1",
+    name: "Daily Backup",
+    schedule: "0 0 * * *",
+    execution: { type: "ShellCommand" as const, value: "backup.sh" },
+    enabled: true,
+    timezone: null,
+    working_dir: null,
+    env_vars: null,
+    timeout_secs: 3600,
+    log_environment: false,
+    allow_concurrent: false,
+    pre_hook: null,
+    post_hook: null,
+    pre_hook_script_type: null,
+    post_hook_script_type: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    last_run_at: null,
+    last_exit_code: null,
+    next_run_at: "2024-01-02T00:00:00Z",
+  },
+  {
+    id: "job-2",
+    name: "Weekly Report",
+    schedule: "0 9 * * 1",
+    execution: { type: "ShellCommand" as const, value: "report.sh" },
+    enabled: true,
+    timezone: "America/New_York",
+    working_dir: "/app",
+    env_vars: { NODE_ENV: "production" },
+    timeout_secs: 1800,
+    log_environment: true,
+    allow_concurrent: false,
+    pre_hook: null,
+    post_hook: null,
+    pre_hook_script_type: null,
+    post_hook_script_type: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    last_run_at: "2024-01-08T09:00:00Z",
+    last_exit_code: 0,
+    next_run_at: "2024-01-15T09:00:00Z",
+  },
+];
+
+describe("useJobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts with loading true", () => {
+    mockApi.listJobs.mockResolvedValue(mockJobs);
+    const { result } = renderHook(() => useJobs());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("returns jobs array on successful fetch", async () => {
+    mockApi.listJobs.mockResolvedValue(mockJobs);
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.jobs).toEqual(mockJobs);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("starts with empty jobs array", () => {
+    mockApi.listJobs.mockResolvedValue(mockJobs);
+    const { result } = renderHook(() => useJobs());
+    expect(result.current.jobs).toEqual([]);
+  });
+
+  it("sets error on API failure", async () => {
+    mockApi.listJobs.mockRejectedValue(new Error("Failed to fetch jobs"));
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Failed to fetch jobs");
+    expect(result.current.jobs).toEqual([]);
+  });
+
+  it("handles non-array response gracefully", async () => {
+    mockApi.listJobs.mockResolvedValue(null);
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Non-array result means jobs remains unchanged (empty)
+    expect(result.current.jobs).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("refresh triggers re-fetch", async () => {
+    mockApi.listJobs.mockResolvedValue(mockJobs);
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockApi.listJobs).toHaveBeenCalledTimes(1);
+
+    const newJob = {
+      id: "job-3",
+      name: "New Job",
+      schedule: "*/5 * * * *",
+      execution: { type: "ShellCommand" as const, value: "new-job.sh" },
+      enabled: false,
+      timezone: null,
+      working_dir: null,
+      env_vars: null,
+      timeout_secs: 300,
+      log_environment: false,
+      allow_concurrent: true,
+      pre_hook: null,
+      post_hook: null,
+      pre_hook_script_type: null,
+      post_hook_script_type: null,
+      created_at: "2024-01-02T00:00:00Z",
+      updated_at: "2024-01-02T00:00:00Z",
+      last_run_at: null,
+      last_exit_code: null,
+      next_run_at: null,
+    };
+    mockApi.listJobs.mockResolvedValue([...mockJobs, newJob]);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockApi.listJobs).toHaveBeenCalledTimes(2);
+    expect(result.current.jobs).toHaveLength(3);
+    expect(result.current.jobs[2]).toEqual(newJob);
+  });
+});

--- a/electron/packages/frontend-v2/src/hooks/__tests__/useRecentRuns.test.ts
+++ b/electron/packages/frontend-v2/src/hooks/__tests__/useRecentRuns.test.ts
@@ -1,0 +1,115 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listRecentRuns: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useRecentRuns } from "../useRecentRuns";
+
+const mockApi = api as { listRecentRuns: ReturnType<typeof vi.fn> };
+
+const mockRuns = [
+  {
+    run_id: "run-1",
+    job_id: "job-1",
+    job_name: "Daily Backup",
+    started_at: "2024-01-01T10:00:00Z",
+    finished_at: "2024-01-01T10:05:00Z",
+    status: "Completed" as const,
+    exit_code: 0,
+    log_size_bytes: 1024,
+    error: null,
+  },
+  {
+    run_id: "run-2",
+    job_id: "job-2",
+    job_name: "Weekly Report",
+    started_at: "2024-01-01T09:00:00Z",
+    finished_at: "2024-01-01T09:10:00Z",
+    status: "Failed" as const,
+    exit_code: 1,
+    log_size_bytes: 512,
+    error: "Command failed",
+  },
+];
+
+const mockResponse = { runs: mockRuns, limit: 12 };
+
+describe("useRecentRuns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts with loading true", () => {
+    mockApi.listRecentRuns.mockResolvedValue(mockResponse);
+    const { result } = renderHook(() => useRecentRuns());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("returns runs array on successful fetch", async () => {
+    mockApi.listRecentRuns.mockResolvedValue(mockResponse);
+    const { result } = renderHook(() => useRecentRuns());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.runs).toEqual(mockRuns);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("respects limit parameter", async () => {
+    mockApi.listRecentRuns.mockResolvedValue({ runs: mockRuns.slice(0, 1), limit: 5 });
+    renderHook(() => useRecentRuns(5));
+
+    await waitFor(() => expect(mockApi.listRecentRuns).toHaveBeenCalledWith(5));
+  });
+
+  it("uses default limit of 12", async () => {
+    mockApi.listRecentRuns.mockResolvedValue(mockResponse);
+    renderHook(() => useRecentRuns());
+
+    await waitFor(() => expect(mockApi.listRecentRuns).toHaveBeenCalledWith(12));
+  });
+
+  it("sets error on API failure", async () => {
+    mockApi.listRecentRuns.mockRejectedValue(new Error("Failed to fetch recent runs"));
+    const { result } = renderHook(() => useRecentRuns());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Failed to fetch recent runs");
+    expect(result.current.runs).toEqual([]);
+  });
+
+  it("refresh triggers re-fetch", async () => {
+    mockApi.listRecentRuns.mockResolvedValue(mockResponse);
+    const { result } = renderHook(() => useRecentRuns());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockApi.listRecentRuns).toHaveBeenCalledTimes(1);
+
+    const newRun = {
+      run_id: "run-3",
+      job_id: "job-3",
+      job_name: "New Job",
+      started_at: "2024-01-02T10:00:00Z",
+      finished_at: null,
+      status: "Running" as const,
+      exit_code: null,
+      log_size_bytes: 0,
+      error: null,
+    };
+    const updatedResponse = { runs: [newRun, ...mockRuns], limit: 12 };
+    mockApi.listRecentRuns.mockResolvedValue(updatedResponse);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockApi.listRecentRuns).toHaveBeenCalledTimes(2);
+    expect(result.current.runs).toEqual(updatedResponse.runs);
+  });
+});

--- a/electron/packages/frontend-v2/src/hooks/__tests__/useSystemLogs.test.ts
+++ b/electron/packages/frontend-v2/src/hooks/__tests__/useSystemLogs.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getSystemLogs: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useSystemLogs } from "../useSystemLogs";
+
+const mockApi = api as { getSystemLogs: ReturnType<typeof vi.fn> };
+
+const mockLogs = "2024-01-01 INFO: Service started\n2024-01-01 INFO: Job scheduled";
+
+describe("useSystemLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts with loading true", () => {
+    mockApi.getSystemLogs.mockResolvedValue(mockLogs);
+    const { result } = renderHook(() => useSystemLogs());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("returns logs string on successful fetch", async () => {
+    mockApi.getSystemLogs.mockResolvedValue(mockLogs);
+    const { result } = renderHook(() => useSystemLogs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.logs).toBe(mockLogs);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("respects tail parameter", async () => {
+    mockApi.getSystemLogs.mockResolvedValue(mockLogs);
+    renderHook(() => useSystemLogs(50));
+
+    await waitFor(() => expect(mockApi.getSystemLogs).toHaveBeenCalledWith(50));
+  });
+
+  it("uses default tail of 100", async () => {
+    mockApi.getSystemLogs.mockResolvedValue(mockLogs);
+    renderHook(() => useSystemLogs());
+
+    await waitFor(() => expect(mockApi.getSystemLogs).toHaveBeenCalledWith(100));
+  });
+
+  it("sets error on API failure", async () => {
+    mockApi.getSystemLogs.mockRejectedValue(new Error("Failed to load logs"));
+    const { result } = renderHook(() => useSystemLogs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Failed to load logs");
+    expect(result.current.logs).toBe("");
+  });
+
+  it("refresh triggers re-fetch", async () => {
+    mockApi.getSystemLogs.mockResolvedValue(mockLogs);
+    const { result } = renderHook(() => useSystemLogs());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockApi.getSystemLogs).toHaveBeenCalledTimes(1);
+
+    const newLogs = mockLogs + "\n2024-01-01 INFO: Additional log entry";
+    mockApi.getSystemLogs.mockResolvedValue(newLogs);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockApi.getSystemLogs).toHaveBeenCalledTimes(2);
+    expect(result.current.logs).toBe(newLogs);
+  });
+});

--- a/electron/packages/frontend-v2/src/hooks/useGlobalCostSummary.ts
+++ b/electron/packages/frontend-v2/src/hooks/useGlobalCostSummary.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
+import type { GlobalCostSummaryResponse } from "@/lib/types";
+
+export function useGlobalCostSummary() {
+  const [summary, setSummary] = useState<GlobalCostSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await api.getGlobalCostSummary();
+      setSummary(result);
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch global cost summary"
+      );
+      setSummary(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { summary, loading, error, refresh };
+}

--- a/electron/packages/frontend-v2/src/hooks/useHealth.ts
+++ b/electron/packages/frontend-v2/src/hooks/useHealth.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
+import type { HealthResponse } from "@/lib/types";
+
+export function useHealth(intervalMs: number = 5000) {
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const data = await api.health();
+      setHealth(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch health");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHealth();
+    const timer = setInterval(fetchHealth, intervalMs);
+    return () => clearInterval(timer);
+  }, [fetchHealth, intervalMs]);
+
+  return { health, loading, error, refresh: fetchHealth };
+}

--- a/electron/packages/frontend-v2/src/hooks/useJobs.ts
+++ b/electron/packages/frontend-v2/src/hooks/useJobs.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
+import type { Job } from "@/lib/types";
+
+export function useJobs() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.listJobs();
+      if (Array.isArray(data)) {
+        setJobs(data);
+      }
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch jobs");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { jobs, loading, error, refresh };
+}

--- a/electron/packages/frontend-v2/src/hooks/useRecentRuns.ts
+++ b/electron/packages/frontend-v2/src/hooks/useRecentRuns.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
+import type { RecentRunEntry } from "@/lib/types";
+
+export function useRecentRuns(limit: number = 12) {
+  const [runs, setRuns] = useState<RecentRunEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.listRecentRuns(limit);
+      setRuns(data.runs);
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch recent runs"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { runs, loading, error, refresh };
+}

--- a/electron/packages/frontend-v2/src/hooks/useSystemLogs.ts
+++ b/electron/packages/frontend-v2/src/hooks/useSystemLogs.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
+
+export function useSystemLogs(tail: number = 100) {
+  const [logs, setLogs] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.getSystemLogs(tail);
+      setLogs(data);
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch system logs"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [tail]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { logs, loading, error, refresh };
+}

--- a/electron/packages/frontend-v2/src/lib/ansi.ts
+++ b/electron/packages/frontend-v2/src/lib/ansi.ts
@@ -1,0 +1,9 @@
+import Anser from "anser";
+
+export function ansiToHtml(text: string): string {
+  return Anser.ansiToHtml(Anser.escapeForHtml(text), { use_classes: false });
+}
+
+export function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}

--- a/electron/packages/frontend-v2/src/routes/MonitoringPage.tsx
+++ b/electron/packages/frontend-v2/src/routes/MonitoringPage.tsx
@@ -1,8 +1,55 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+import { useHealth } from "@/hooks/useHealth";
+import { useGlobalCostSummary } from "@/hooks/useGlobalCostSummary";
+import { useJobs } from "@/hooks/useJobs";
+import { useSSEEvents } from "@/hooks/useSSE";
+import { HeroSection } from "@/components/dashboard/HeroSection";
+import { RecentRuns } from "@/components/dashboard/RecentRuns";
+import { SystemLogs } from "@/components/dashboard/SystemLogs";
+import { Footer } from "@/components/dashboard/Footer";
+
 export function MonitoringPage() {
+  const { health, refresh: healthRefresh } = useHealth(5000);
+  const { summary, refresh: summaryRefresh } = useGlobalCostSummary();
+  const { jobs, refresh: jobsRefresh } = useJobs();
+
+  // SSE event wiring: refresh data on relevant events
+  useSSEEvents(
+    useCallback(
+      (event) => {
+        if (
+          event.type === "job_changed" ||
+          event.type === "completed" ||
+          event.type === "failed" ||
+          event.type === "killed"
+        ) {
+          healthRefresh();
+          summaryRefresh();
+          jobsRefresh();
+        }
+      },
+      [healthRefresh, summaryRefresh, jobsRefresh]
+    )
+  );
+
+  // Scroll-to-logs ref
+  const logsRef = useRef<HTMLDivElement>(null);
+  const scrollToLogs = useCallback(() => {
+    logsRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
   return (
-    <div className="p-6">
-      <h1 className="text-xl font-semibold">Dashboard</h1>
-      <p className="text-sm text-muted-foreground mt-2">Monitoring page — coming in #107</p>
+    <div className="flex flex-col min-h-full">
+      <div className="flex-1 mx-auto w-full max-w-6xl px-6 py-6 space-y-6 pb-12">
+        <HeroSection summary={summary} jobs={jobs} scrollToLogs={scrollToLogs} />
+        <RecentRuns />
+        <div ref={logsRef}>
+          <SystemLogs />
+        </div>
+      </div>
+      <Footer health={health} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Implements the full dashboard page for the frontend redesign (#107), replacing the MonitoringPage placeholder with a complete dashboard
- Includes hero section with widget carousel, recent runs grid, system logs viewer, and health footer
- Ports LogViewer from old frontend, creates 5 data-fetching hooks, 3 SVG chart components, and full test coverage
- Relates to #107

## Changes
| File | Change |
|------|--------|
| `src/lib/ansi.ts` | Port ANSI utility from old frontend |
| `src/hooks/useHealth.ts` | Health polling hook (5s interval) |
| `src/hooks/useSystemLogs.ts` | System logs fetching hook |
| `src/hooks/useGlobalCostSummary.ts` | Global cost summary hook |
| `src/hooks/useRecentRuns.ts` | Recent runs fetching hook |
| `src/hooks/useJobs.ts` | Jobs list fetching hook |
| `src/components/dashboard/ChatInput.tsx` | Visual chat placeholder (no backend) |
| `src/components/dashboard/QuickActions.tsx` | Quick action pill buttons |
| `src/components/dashboard/Footer.tsx` | Health status footer bar |
| `src/components/dashboard/LogViewer.tsx` | Full log viewer port (~600 lines) |
| `src/components/dashboard/SystemLogs.tsx` | System logs with tail selector + auto-refresh |
| `src/components/dashboard/WidgetCarousel.tsx` | Auto-rotating carousel (5s, hover-pause) |
| `src/components/dashboard/charts/DonutChart.tsx` | SVG donut chart for top cost jobs |
| `src/components/dashboard/charts/BarChart.tsx` | SVG bar chart for daily cost trend |
| `src/components/dashboard/charts/NextRunTimer.tsx` | Countdown to next scheduled run |
| `src/components/dashboard/HeroSection.tsx` | Two-column hero (55/45) composition |
| `src/components/dashboard/RecentRuns.tsx` | Responsive grid of recent run cards |
| `src/routes/MonitoringPage.tsx` | Full dashboard composition with SSE wiring |
| `README.md` | Updated frontend-v2 description |

## AI Suggested Testing Plan
- [ ] Run `npm test` in `electron/packages/frontend-v2/` — all 183 tests should pass
- [ ] Start the backend and verify dashboard loads at `/`
- [ ] Verify hero section renders with carousel auto-rotating every 5s
- [ ] Verify carousel pauses on hover
- [ ] Verify quick actions: Jobs navigates, Restart confirms, System Logs scrolls
- [ ] Verify recent runs grid shows 12 cards with status badges
- [ ] Verify system logs with tail size selector and auto-refresh toggle
- [ ] Verify footer shows health data (uptime, jobs, version)
- [ ] Test all 4 theme combinations (light/dark × burgundy/sage)
- [ ] Verify SSE events trigger data refreshes

## Ticket
#107 — https://github.com/Jtonna/agent-cron-scheduler/issues/107

---
Generated by the starterpack orchestrator.