### PR TITLE
ACS-25: cascade workflow delete + run purge endpoints + durable cost ledger

### DIFF
--- a/acs/Cargo.lock
+++ b/acs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-cron-scheduler"
-version = "4.2.13"
+version = "4.2.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/acs/Cargo.toml
+++ b/acs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-cron-scheduler"
-version = "4.2.13"
+version = "4.2.14"
 edition = "2021"
 license = "MIT"
 

--- a/acs/src/daemon/cost_cache.rs
+++ b/acs/src/daemon/cost_cache.rs
@@ -394,6 +394,12 @@ mod tests {
         async fn delete_run(&self, _run_id: Uuid) -> Result<(), AcsError> {
             unimplemented!()
         }
+        async fn purge_runs(&self, _workflow_id: Uuid) -> Result<Vec<Uuid>, AcsError> {
+            unimplemented!()
+        }
+        async fn list_ledger_workflows(&self) -> Result<Vec<(Uuid, String)>, AcsError> {
+            Ok(Vec::new())
+        }
         async fn cost_summary_for(
             &self,
             _workflow_id: Uuid,

--- a/acs/src/migration/m008_cost_ledger_cascade.rs
+++ b/acs/src/migration/m008_cost_ledger_cascade.rs
@@ -1,0 +1,377 @@
+//! Migration 008 — durable cost ledger + `ON DELETE CASCADE` on
+//! `workflow_runs.workflow_id`.
+//!
+//! # Background
+//!
+//! v4.2.14 fixes `DELETE /api/workflows/{id}` returning a 500
+//! (`FOREIGN KEY constraint failed`) for any workflow with run history, and
+//! introduces the `cost_ledger` table so cost/token bookkeeping survives
+//! deletion of workflows and runs.
+//!
+//! # What this migration does
+//!
+//! If `acs.db` does not exist → return `Ok(false)` (fresh install — the
+//! ledger table and the CASCADE clause are present from the start via
+//! `schema.rs`).
+//!
+//! If the `workflow_runs.workflow_id` FK already has `ON DELETE CASCADE` →
+//! return `Ok(false)` (idempotent).
+//!
+//! Otherwise:
+//!
+//! 1. Backfill `cost_ledger` from every terminal (`Completed` / `Failed` /
+//!    `Killed`) row in `workflow_runs`, extracting `workflow_name` from the
+//!    stored workflow snapshot. `INSERT OR IGNORE` keeps re-runs safe.
+//! 2. Rebuild `workflow_runs` with `ON DELETE CASCADE` on the FK. SQLite
+//!    cannot alter an existing FK, so this is the standard table rebuild:
+//!    create new table → copy rows → drop old → rename → recreate indexes.
+//!    The rebuild runs with `PRAGMA foreign_keys = OFF` (a no-op inside a
+//!    transaction, so it is toggled outside of one) and everything else in a
+//!    single transaction.
+//!
+//! The `cost_ledger` table itself is created by `schema.rs` (`apply_schema`
+//! runs on every open, and `open_with_schema` below applies it) — this
+//! migration only needs to populate it and rebuild the runs table.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use rusqlite::Connection;
+
+use crate::errors::AcsError;
+use crate::migration::Migration;
+use crate::storage::sqlite;
+
+pub struct CostLedgerCascade;
+
+#[async_trait]
+impl Migration for CostLedgerCascade {
+    fn name(&self) -> &'static str {
+        "m008_cost_ledger_cascade"
+    }
+
+    async fn run(&self, data_dir: &Path) -> Result<bool, AcsError> {
+        let db_path = data_dir.join("acs.db");
+        if !db_path.exists() {
+            return Ok(false);
+        }
+        let db_path_clone = db_path.clone();
+        tokio::task::spawn_blocking(move || run_blocking(&db_path_clone))
+            .await
+            .map_err(|e| AcsError::Internal(format!("blocking task failed: {}", e)))?
+    }
+}
+
+/// Return `true` when the `workflow_runs.workflow_id` FK already declares
+/// `ON DELETE CASCADE`.
+fn fk_has_cascade(conn: &Connection) -> Result<bool, AcsError> {
+    // PRAGMA foreign_key_list returns one row per FK with fields:
+    //   id | seq | table | from | to | on_update | on_delete | match
+    let mut stmt = conn
+        .prepare("PRAGMA foreign_key_list(workflow_runs)")
+        .map_err(|e| {
+            AcsError::Storage(format!("Failed to prepare PRAGMA foreign_key_list: {}", e))
+        })?;
+    let on_deletes: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(6))
+        .map_err(|e| AcsError::Storage(format!("Failed to query PRAGMA foreign_key_list: {}", e)))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AcsError::Storage(format!("Failed to collect FK rows: {}", e)))?;
+    Ok(on_deletes.iter().any(|d| d == "CASCADE"))
+}
+
+fn run_blocking(db_path: &Path) -> Result<bool, AcsError> {
+    // open_with_schema applies pragmas and the current schema — this creates
+    // the (empty) cost_ledger table on databases from older versions.
+    let mut conn = sqlite::open_with_schema(db_path)?;
+
+    // Idempotency check: the CASCADE clause is the last thing this migration
+    // installs, so its presence means the whole migration already ran (or the
+    // DB was created fresh with the current schema).
+    if fk_has_cascade(&conn)? {
+        return Ok(false);
+    }
+
+    // The table rebuild must not fire FK checks mid-flight. PRAGMA
+    // foreign_keys is a no-op inside a transaction, so toggle it outside.
+    conn.execute_batch("PRAGMA foreign_keys = OFF;")
+        .map_err(|e| AcsError::Storage(format!("Failed to disable foreign_keys: {}", e)))?;
+
+    let result = (|| -> Result<(usize, usize), AcsError> {
+        let tx = conn
+            .transaction()
+            .map_err(|e| AcsError::Storage(format!("Failed to start transaction: {}", e)))?;
+
+        // 1. Backfill the ledger from existing terminal runs. workflow_name
+        //    comes from the persisted workflow snapshot JSON.
+        let backfilled = tx
+            .execute(
+                "INSERT OR IGNORE INTO cost_ledger (
+                    run_id, workflow_id, workflow_name, started_at, finished_at,
+                    status, total_cost_usd, total_input_tokens, total_output_tokens
+                 )
+                 SELECT run_id,
+                        workflow_id,
+                        COALESCE(json_extract(workflow_snapshot, '$.name'), ''),
+                        started_at,
+                        finished_at,
+                        status,
+                        total_cost_usd,
+                        COALESCE(total_input_tokens, 0),
+                        COALESCE(total_output_tokens, 0)
+                 FROM workflow_runs
+                 WHERE status IN ('Completed', 'Failed', 'Killed')",
+                [],
+            )
+            .map_err(|e| AcsError::Storage(format!("cost_ledger backfill failed: {}", e)))?;
+
+        // 2. Rebuild workflow_runs with ON DELETE CASCADE.
+        tx.execute_batch(
+            "CREATE TABLE workflow_runs_new (
+                run_id              TEXT PRIMARY KEY,
+                workflow_id         TEXT NOT NULL,
+                workflow_version    INTEGER NOT NULL,
+                workflow_snapshot   TEXT NOT NULL,
+                started_at          TEXT NOT NULL,
+                finished_at         TEXT,
+                status              TEXT NOT NULL,
+                trigger_input       TEXT,
+                steps_json          TEXT NOT NULL,
+                total_cost_usd         REAL,
+                total_duration_ms      INTEGER,
+                total_input_tokens     INTEGER NOT NULL DEFAULT 0,
+                total_output_tokens    INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
+             );
+             INSERT INTO workflow_runs_new (
+                run_id, workflow_id, workflow_version, workflow_snapshot,
+                started_at, finished_at, status, trigger_input, steps_json,
+                total_cost_usd, total_duration_ms,
+                total_input_tokens, total_output_tokens
+             )
+             SELECT run_id, workflow_id, workflow_version, workflow_snapshot,
+                    started_at, finished_at, status, trigger_input, steps_json,
+                    total_cost_usd, total_duration_ms,
+                    total_input_tokens, total_output_tokens
+             FROM workflow_runs;
+             DROP TABLE workflow_runs;
+             ALTER TABLE workflow_runs_new RENAME TO workflow_runs;
+             CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_id_finished_at
+                 ON workflow_runs(workflow_id, finished_at);
+             CREATE INDEX IF NOT EXISTS idx_workflow_runs_finished_at
+                 ON workflow_runs(finished_at);
+             CREATE INDEX IF NOT EXISTS idx_workflow_runs_status
+                 ON workflow_runs(status);",
+        )
+        .map_err(|e| AcsError::Storage(format!("workflow_runs rebuild failed: {}", e)))?;
+
+        let copied: usize = tx
+            .query_row("SELECT COUNT(*) FROM workflow_runs", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .map(|n| n as usize)
+            .map_err(|e| AcsError::Storage(format!("post-rebuild count failed: {}", e)))?;
+
+        tx.commit()
+            .map_err(|e| AcsError::Storage(format!("COMMIT failed: {}", e)))?;
+        Ok((backfilled, copied))
+    })();
+
+    // Always restore the FK pragma, even when the transaction failed.
+    let restore = conn
+        .execute_batch("PRAGMA foreign_keys = ON;")
+        .map_err(|e| AcsError::Storage(format!("Failed to re-enable foreign_keys: {}", e)));
+
+    let (backfilled, copied) = result?;
+    restore?;
+
+    tracing::info!(
+        "Migration m008 complete: backfilled {} cost_ledger row(s) and rebuilt \
+         workflow_runs ({} row(s)) with ON DELETE CASCADE",
+        backfilled,
+        copied
+    );
+    Ok(true)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    /// DDL matching a v4.2.13 database: token columns present (m007 applied),
+    /// no cost_ledger table, no CASCADE on the FK.
+    const OLD_SCHEMA: &str = "
+        PRAGMA journal_mode = WAL;
+        PRAGMA foreign_keys = ON;
+        PRAGMA synchronous = NORMAL;
+        CREATE TABLE IF NOT EXISTS workflows (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+            version INTEGER NOT NULL, schedule TEXT NOT NULL,
+            timezone TEXT, schedule_mode TEXT NOT NULL,
+            enabled INTEGER NOT NULL, steps_json TEXT NOT NULL,
+            default_input TEXT, working_dir TEXT, env_vars TEXT,
+            allow_concurrent INTEGER NOT NULL, on_failure TEXT NOT NULL,
+            last_run_at TEXT, last_run_status TEXT, last_run_id TEXT,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            is_favorited INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS workflow_runs (
+            run_id TEXT PRIMARY KEY, workflow_id TEXT NOT NULL,
+            workflow_version INTEGER NOT NULL, workflow_snapshot TEXT NOT NULL,
+            started_at TEXT NOT NULL, finished_at TEXT,
+            status TEXT NOT NULL, trigger_input TEXT,
+            steps_json TEXT NOT NULL, total_cost_usd REAL,
+            total_duration_ms INTEGER,
+            total_input_tokens INTEGER NOT NULL DEFAULT 0,
+            total_output_tokens INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_id_finished_at
+            ON workflow_runs(workflow_id, finished_at);
+        CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);";
+
+    fn seed_old_db(db_path: &Path) {
+        let conn = Connection::open(db_path).expect("open");
+        conn.execute_batch(OLD_SCHEMA).expect("apply old schema");
+        conn.execute_batch(
+            "INSERT INTO workflows (id, name, version, schedule, schedule_mode, enabled,
+                steps_json, allow_concurrent, on_failure, created_at, updated_at)
+             VALUES ('wf-1', 'legacy-wf', 1, '* * * * *', 'cron', 1, '[]', 1, 'abort',
+                '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z');
+             INSERT INTO workflow_runs (run_id, workflow_id, workflow_version,
+                workflow_snapshot, started_at, finished_at, status, steps_json,
+                total_cost_usd, total_input_tokens, total_output_tokens)
+             VALUES
+                ('run-1', 'wf-1', 1, '{\"name\":\"legacy-wf\"}',
+                 '2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z', 'Completed', '[]',
+                 0.25, 100, 50),
+                ('run-2', 'wf-1', 1, '{\"name\":\"legacy-wf\"}',
+                 '2026-01-02T00:00:00Z', '2026-01-02T00:01:00Z', 'Failed', '[]',
+                 NULL, 0, 0),
+                ('run-3', 'wf-1', 1, '{\"name\":\"legacy-wf\"}',
+                 '2026-01-03T00:00:00Z', NULL, 'Running', '[]',
+                 NULL, 0, 0);",
+        )
+        .expect("seed rows");
+    }
+
+    // ── Test 1: no acs.db → no-op ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_no_db_file_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let m = CostLedgerCascade;
+        let did_work = m.run(tmp.path()).await.expect("migrate");
+        assert!(!did_work, "missing acs.db must be a no-op");
+    }
+
+    // ── Test 2: fresh DB created with the current schema → no-op ─────────────
+
+    #[tokio::test]
+    async fn test_fresh_db_with_cascade_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("acs.db");
+        // Fresh DB via the current schema — CASCADE is already present.
+        let _db = crate::storage::sqlite::init_db(&db_path).expect("init");
+        let m = CostLedgerCascade;
+        let did_work = m.run(tmp.path()).await.expect("migrate");
+        assert!(!did_work, "fresh DB already has CASCADE → no-op");
+    }
+
+    // ── Test 3: old DB → backfills ledger and installs CASCADE ────────────────
+
+    #[tokio::test]
+    async fn test_backfills_ledger_and_installs_cascade() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("acs.db");
+        seed_old_db(&db_path);
+
+        let m = CostLedgerCascade;
+        let did_work = m.run(tmp.path()).await.expect("migrate");
+        assert!(did_work, "old DB must be migrated");
+
+        let conn = crate::storage::sqlite::open_with_schema(&db_path).expect("reopen");
+
+        // Ledger contains only the two terminal runs.
+        let ledger_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM cost_ledger", [], |r| r.get(0))
+            .expect("count ledger");
+        assert_eq!(ledger_count, 2, "only terminal runs are backfilled");
+
+        // workflow_name extracted from the snapshot.
+        let name: String = conn
+            .query_row(
+                "SELECT workflow_name FROM cost_ledger WHERE run_id = 'run-1'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("ledger name");
+        assert_eq!(name, "legacy-wf");
+
+        // Cost + tokens preserved.
+        let (cost, in_tok, out_tok): (f64, i64, i64) = conn
+            .query_row(
+                "SELECT total_cost_usd, total_input_tokens, total_output_tokens \
+                 FROM cost_ledger WHERE run_id = 'run-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("ledger row");
+        assert!((cost - 0.25).abs() < 1e-9);
+        assert_eq!(in_tok, 100);
+        assert_eq!(out_tok, 50);
+
+        // All three run rows survived the rebuild.
+        let run_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM workflow_runs", [], |r| r.get(0))
+            .expect("count runs");
+        assert_eq!(run_count, 3);
+
+        // FK now cascades.
+        assert!(
+            fk_has_cascade(&conn).expect("fk check"),
+            "workflow_runs FK must be ON DELETE CASCADE after migration"
+        );
+
+        // ...and it actually works: deleting the workflow removes its runs.
+        conn.execute("DELETE FROM workflows WHERE id = 'wf-1'", [])
+            .expect("delete workflow");
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM workflow_runs", [], |r| r.get(0))
+            .expect("count runs after delete");
+        assert_eq!(remaining, 0, "CASCADE must delete child runs");
+
+        // The ledger is untouched by the cascade.
+        let ledger_after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM cost_ledger", [], |r| r.get(0))
+            .expect("count ledger after delete");
+        assert_eq!(ledger_after, 2);
+    }
+
+    // ── Test 4: idempotent — second run is a no-op ────────────────────────────
+
+    #[tokio::test]
+    async fn test_idempotent_second_run_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("acs.db");
+        seed_old_db(&db_path);
+
+        let m = CostLedgerCascade;
+        assert!(m.run(tmp.path()).await.expect("first run"));
+        assert!(
+            !m.run(tmp.path()).await.expect("second run"),
+            "second run must be a no-op"
+        );
+
+        // Backfill did not duplicate rows.
+        let conn = Connection::open(&db_path).expect("open");
+        let ledger_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM cost_ledger", [], |r| r.get(0))
+            .expect("count ledger");
+        assert_eq!(ledger_count, 2);
+    }
+}

--- a/acs/src/migration/mod.rs
+++ b/acs/src/migration/mod.rs
@@ -33,6 +33,7 @@ mod m004_drop_input_schema;
 mod m005_shell_claude_to_agent;
 mod m006_agent_step_normalize;
 mod m007_add_token_columns;
+mod m008_cost_ledger_cascade;
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -77,6 +78,7 @@ fn registry() -> Vec<Box<dyn Migration>> {
         Box::new(m005_shell_claude_to_agent::ShellClaudeToAgent),
         Box::new(m006_agent_step_normalize::AgentStepNormalize),
         Box::new(m007_add_token_columns::AddTokenColumns),
+        Box::new(m008_cost_ledger_cascade::CostLedgerCascade),
     ]
 }
 

--- a/acs/src/server/mod.rs
+++ b/acs/src/server/mod.rs
@@ -70,10 +70,13 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .route(
             "/api/workflows/{id}/runs",
-            get(workflow_routes::list_workflow_runs),
+            get(workflow_routes::list_workflow_runs).delete(workflow_routes::purge_workflow_runs),
         )
         .route("/api/runs/recent", get(workflow_routes::list_recent_runs))
-        .route("/api/runs/{run_id}", get(workflow_routes::get_workflow_run))
+        .route(
+            "/api/runs/{run_id}",
+            get(workflow_routes::get_workflow_run).delete(workflow_routes::delete_workflow_run),
+        )
         .route(
             "/api/runs/{run_id}/kill",
             post(workflow_routes::kill_workflow_run),

--- a/acs/src/server/workflow_routes.rs
+++ b/acs/src/server/workflow_routes.rs
@@ -123,6 +123,27 @@ fn map_store_error(e: anyhow::Error) -> (StatusCode, Json<ErrorResponse>) {
                     message: msg.clone(),
                 }),
             ),
+            // Constraint violations surfaced as raw storage errors (e.g. a
+            // FOREIGN KEY / UNIQUE failure from a code path without an
+            // explicit guard) are conflicts the caller can resolve, not
+            // internal server faults. Code paths that can classify the
+            // conflict precisely should return AcsError::Conflict instead;
+            // this string match is the fallback.
+            AcsError::Storage(msg)
+                if msg.contains("FOREIGN KEY") || msg.to_lowercase().contains("constraint") =>
+            {
+                (
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        error: "conflict".to_string(),
+                        message: format!(
+                            "Operation conflicts with existing data: {}. \
+                             If you are deleting a workflow, purge or wait for its runs first.",
+                            msg
+                        ),
+                    }),
+                )
+            }
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
@@ -595,7 +616,26 @@ pub async fn list_workflow_costs(
         }
     };
 
-    let mut entries = Vec::with_capacity(workflows.len());
+    // The list covers live workflows plus workflows that only exist in the
+    // durable cost ledger any more (deleted, but their spend still counts).
+    // For deleted workflows the ledger's stored name is used.
+    let live_ids: std::collections::HashSet<Uuid> = workflows.iter().map(|w| w.id).collect();
+    let mut id_name_pairs: Vec<(Uuid, String)> =
+        workflows.iter().map(|w| (w.id, w.name.clone())).collect();
+    match state.workflow_run_store.list_ledger_workflows().await {
+        Ok(ledger_workflows) => {
+            for (wf_id, wf_name) in ledger_workflows {
+                if !live_ids.contains(&wf_id) {
+                    id_name_pairs.push((wf_id, wf_name));
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("list_ledger_workflows failed: {}", e);
+        }
+    }
+
+    let mut entries = Vec::with_capacity(id_name_pairs.len());
     let mut system_30d_total = 0.0f64;
     let mut system_30d_runs = 0u64;
     let mut system_year_total = 0.0f64;
@@ -605,22 +645,22 @@ pub async fn list_workflow_costs(
     let mut system_year_input_tokens = 0u64;
     let mut system_year_output_tokens = 0u64;
 
-    for wf in &workflows {
-        let mut cost_summary = match state.cost_cache.get(wf.id).await {
+    for (wf_id, wf_name) in id_name_pairs {
+        let mut cost_summary = match state.cost_cache.get(wf_id).await {
             Ok(s) => s,
             Err(e) => {
-                tracing::warn!(workflow_id = %wf.id, "cost_cache.get failed: {}", e);
+                tracing::warn!(workflow_id = %wf_id, "cost_cache.get failed: {}", e);
                 continue;
             }
         };
         match state
             .cost_cache
-            .get_daily_buckets_for(wf.id, since, until)
+            .get_daily_buckets_for(wf_id, since, until)
             .await
         {
             Ok(buckets) => cost_summary.daily_buckets = buckets,
             Err(e) => {
-                tracing::warn!(workflow_id = %wf.id, "cost_cache.get_daily_buckets_for failed: {}", e);
+                tracing::warn!(workflow_id = %wf_id, "cost_cache.get_daily_buckets_for failed: {}", e);
             }
         }
         system_30d_total += cost_summary.last_30_days_total_usd;
@@ -632,8 +672,8 @@ pub async fn list_workflow_costs(
         system_year_input_tokens += cost_summary.last_year_input_tokens;
         system_year_output_tokens += cost_summary.last_year_output_tokens;
         entries.push(WorkflowCostEntry {
-            workflow_id: wf.id,
-            workflow_name: wf.name.clone(),
+            workflow_id: wf_id,
+            workflow_name: wf_name,
             cost_summary,
         });
     }
@@ -713,15 +753,32 @@ pub async fn get_workflow_costs(
         Err((status, body)) => return (status, body).into_response(),
     };
 
-    let workflow = match state.workflow_store.get_workflow(workflow_id).await {
-        Ok(Some(wf)) => wf,
+    // Live workflows resolve normally; deleted workflows whose spend is still
+    // in the cost ledger stay queryable, served with the ledger's stored name.
+    let workflow_name = match state.workflow_store.get_workflow(workflow_id).await {
+        Ok(Some(wf)) => wf.name,
         Ok(None) => {
-            return error_response(
-                StatusCode::NOT_FOUND,
-                "not_found",
-                &format!("Workflow with id '{}' not found", workflow_id),
-            )
-            .into_response();
+            let ledger_name = match state.workflow_run_store.list_ledger_workflows().await {
+                Ok(pairs) => pairs
+                    .into_iter()
+                    .find(|(id, _)| *id == workflow_id)
+                    .map(|(_, name)| name),
+                Err(e) => {
+                    tracing::warn!("list_ledger_workflows failed: {}", e);
+                    None
+                }
+            };
+            match ledger_name {
+                Some(name) => name,
+                None => {
+                    return error_response(
+                        StatusCode::NOT_FOUND,
+                        "not_found",
+                        &format!("Workflow with id '{}' not found", workflow_id),
+                    )
+                    .into_response();
+                }
+            }
         }
         Err(e) => {
             return error_response(
@@ -761,7 +818,7 @@ pub async fn get_workflow_costs(
         Json(
             serde_json::to_value(CostWorkflowResponse {
                 workflow_id,
-                workflow_name: workflow.name,
+                workflow_name,
                 cost_summary,
             })
             .unwrap(),
@@ -895,7 +952,25 @@ pub async fn delete_workflow(
 
     match state.workflow_store.delete_workflow(workflow_id).await {
         Ok(()) => {
-            // Evict cache entry for the deleted workflow.
+            // Best-effort: remove the workflow's on-disk log directory. A
+            // failure here must not fail the request — the DB state is
+            // already committed.
+            let log_dir = resolve_data_dir_for(&state)
+                .join("logs")
+                .join(workflow_id.to_string());
+            if let Err(e) = tokio::fs::remove_dir_all(&log_dir).await {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        workflow_id = %workflow_id,
+                        "failed to remove log directory {:?} for deleted workflow: {}",
+                        log_dir,
+                        e
+                    );
+                }
+            }
+            // Evict cache entry for the deleted workflow. Its cost history
+            // remains available via the cost ledger and is recomputed on the
+            // next cost query.
             state.cost_cache.forget(workflow_id).await;
             // Broadcast WorkflowChanged{Deleted}
             let _ = state
@@ -913,6 +988,149 @@ pub async fn delete_workflow(
             (status, body).into_response()
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/runs/{run_id}
+// ---------------------------------------------------------------------------
+
+pub async fn delete_workflow_run(
+    State(state): State<Arc<AppState>>,
+    Path(run_id_str): Path<String>,
+) -> impl IntoResponse {
+    let run_id = match Uuid::parse_str(&run_id_str) {
+        Ok(id) => id,
+        Err(_) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "bad_request",
+                &format!("Invalid run_id '{}'", run_id_str),
+            )
+            .into_response();
+        }
+    };
+
+    let run = match state.workflow_run_store.get_run(run_id).await {
+        Ok(Some(run)) => run,
+        Ok(None) => {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "not_found",
+                &format!("Run '{}' not found", run_id),
+            )
+            .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch run {} for delete: {}", run_id, e);
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                &format!("Failed to fetch run: {}", e),
+            )
+            .into_response();
+        }
+    };
+
+    if run.status == RunStatus::Running {
+        return error_response(
+            StatusCode::CONFLICT,
+            "conflict",
+            &format!(
+                "Run '{}' is still running. Kill it (POST /api/runs/{}/kill) or wait for it \
+                 to finish before deleting it.",
+                run_id, run_id
+            ),
+        )
+        .into_response();
+    }
+
+    if let Err(e) = state.workflow_run_store.delete_run(run_id).await {
+        tracing::error!("Failed to delete run {}: {}", run_id, e);
+        let (status, body) = map_store_error(e.into());
+        return (status, body).into_response();
+    }
+
+    // Best-effort: remove the run's log file. Cost-ledger rows are untouched.
+    let log_path = resolve_data_dir_for(&state)
+        .join("logs")
+        .join(run.workflow_id.to_string())
+        .join(format!("{}.log", run_id));
+    if let Err(e) = tokio::fs::remove_file(&log_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(
+                run_id = %run_id,
+                "failed to remove log file {:?} for deleted run: {}",
+                log_path,
+                e
+            );
+        }
+    }
+
+    tracing::info!(run_id = %run_id, workflow_id = %run.workflow_id, "workflow run deleted");
+    StatusCode::NO_CONTENT.into_response()
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/workflows/{id}/runs
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct PurgeRunsResponse {
+    deleted: usize,
+}
+
+/// Bulk-purge every non-Running run for a workflow (rows + log files,
+/// best-effort). The workflow itself and its cost-ledger history are
+/// untouched; Running runs are skipped.
+pub async fn purge_workflow_runs(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let workflow = match resolve_workflow(&state, &id).await {
+        Ok(w) => w,
+        Err((status, body)) => return (status, body).into_response(),
+    };
+
+    let deleted_ids = match state.workflow_run_store.purge_runs(workflow.id).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::error!("Failed to purge runs for workflow {}: {}", workflow.id, e);
+            let (status, body) = map_store_error(e.into());
+            return (status, body).into_response();
+        }
+    };
+
+    // Best-effort log-file cleanup for each purged run.
+    let log_dir = resolve_data_dir_for(&state)
+        .join("logs")
+        .join(workflow.id.to_string());
+    for run_id in &deleted_ids {
+        let log_path = log_dir.join(format!("{}.log", run_id));
+        if let Err(e) = tokio::fs::remove_file(&log_path).await {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    run_id = %run_id,
+                    "failed to remove log file {:?} for purged run: {}",
+                    log_path,
+                    e
+                );
+            }
+        }
+    }
+
+    tracing::info!(
+        workflow_id = %workflow.id,
+        name = %workflow.name,
+        deleted = deleted_ids.len(),
+        "workflow runs purged"
+    );
+    (
+        StatusCode::OK,
+        Json(PurgeRunsResponse {
+            deleted: deleted_ids.len(),
+        }),
+    )
+        .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -1904,6 +2122,21 @@ mod tests {
         async fn delete_run(&self, run_id: Uuid) -> Result<(), AcsError> {
             self.runs.lock().await.remove(&run_id);
             Ok(())
+        }
+        async fn purge_runs(&self, workflow_id: Uuid) -> Result<Vec<Uuid>, AcsError> {
+            let mut map = self.runs.lock().await;
+            let ids: Vec<Uuid> = map
+                .values()
+                .filter(|r| r.workflow_id == workflow_id && r.status != RunStatus::Running)
+                .map(|r| r.run_id)
+                .collect();
+            for id in &ids {
+                map.remove(id);
+            }
+            Ok(ids)
+        }
+        async fn list_ledger_workflows(&self) -> Result<Vec<(Uuid, String)>, AcsError> {
+            Ok(Vec::new())
         }
         async fn cost_summary_for(
             &self,

--- a/acs/src/storage/sqlite/schema.rs
+++ b/acs/src/storage/sqlite/schema.rs
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS workflow_runs (
     total_duration_ms      INTEGER,
     total_input_tokens     INTEGER NOT NULL DEFAULT 0,
     total_output_tokens    INTEGER NOT NULL DEFAULT 0,
-    FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+    FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_id_finished_at
@@ -71,6 +71,27 @@ CREATE TABLE IF NOT EXISTS meta (
     key     TEXT PRIMARY KEY,
     value   TEXT NOT NULL
 );
+
+-- Durable cost ledger (v4.2.14). One append-only row per terminal run
+-- (Completed / Failed / Killed). Deliberately has NO foreign keys so rows
+-- survive deletion of both the parent workflow and the run record itself —
+-- cost analytics aggregate from this table so deleted history still counts.
+CREATE TABLE IF NOT EXISTS cost_ledger (
+    run_id                 TEXT PRIMARY KEY,
+    workflow_id            TEXT NOT NULL,
+    workflow_name          TEXT NOT NULL,
+    started_at             TEXT NOT NULL,
+    finished_at            TEXT,
+    status                 TEXT NOT NULL,
+    total_cost_usd         REAL,
+    total_input_tokens     INTEGER NOT NULL DEFAULT 0,
+    total_output_tokens    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_ledger_workflow_id_finished_at
+    ON cost_ledger(workflow_id, finished_at);
+CREATE INDEX IF NOT EXISTS idx_cost_ledger_finished_at
+    ON cost_ledger(finished_at);
 "#;
 
 /// Apply pragmas (WAL, foreign_keys, synchronous) to a freshly-opened

--- a/acs/src/storage/sqlite/workflow_runs.rs
+++ b/acs/src/storage/sqlite/workflow_runs.rs
@@ -153,6 +153,51 @@ fn upsert_run(conn: &Connection, run: &WorkflowRun) -> Result<(), AcsError> {
         ],
     )
     .map_err(|e| AcsError::Storage(format!("INSERT/UPDATE workflow_run failed: {}", e)))?;
+
+    // Mirror every terminal run into the durable cost ledger. The ledger has
+    // no foreign keys, so cost/token history survives deletion of both the
+    // workflow and the run record itself.
+    upsert_ledger_row(conn, run)?;
+    Ok(())
+}
+
+/// Insert (or refresh) the cost-ledger row for a terminal run. Non-terminal
+/// (`Running`) runs are skipped — the ledger only records finished work.
+///
+/// Upsert semantics keep this idempotent: the kill route may persist a
+/// `Killed` status moments before the executor's finalize path writes the
+/// authoritative terminal state; the last write wins in both tables.
+fn upsert_ledger_row(conn: &Connection, run: &WorkflowRun) -> Result<(), AcsError> {
+    if run.status == RunStatus::Running {
+        return Ok(());
+    }
+    conn.execute(
+        "INSERT INTO cost_ledger (
+            run_id, workflow_id, workflow_name, started_at, finished_at,
+            status, total_cost_usd, total_input_tokens, total_output_tokens
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(run_id) DO UPDATE SET
+            workflow_id          = excluded.workflow_id,
+            workflow_name        = excluded.workflow_name,
+            started_at           = excluded.started_at,
+            finished_at          = excluded.finished_at,
+            status               = excluded.status,
+            total_cost_usd       = excluded.total_cost_usd,
+            total_input_tokens   = excluded.total_input_tokens,
+            total_output_tokens  = excluded.total_output_tokens",
+        params![
+            run.run_id.to_string(),
+            run.workflow_id.to_string(),
+            run.workflow_snapshot.name,
+            run.started_at.to_rfc3339(),
+            run.finished_at.map(|d| d.to_rfc3339()),
+            run_status_str(&run.status)?,
+            run.total_cost_usd,
+            run.total_input_tokens as i64,
+            run.total_output_tokens as i64,
+        ],
+    )
+    .map_err(|e| AcsError::Storage(format!("INSERT/UPDATE cost_ledger failed: {}", e)))?;
     Ok(())
 }
 
@@ -298,12 +343,89 @@ impl WorkflowRunStore for SqliteWorkflowRunStore {
 
     async fn delete_run(&self, run_id: Uuid) -> Result<(), AcsError> {
         // Best-effort: deleting a row that isn't present is not an error.
+        // Cost-ledger rows are intentionally NOT touched — cost history
+        // survives run deletion.
         let id_s = run_id.to_string();
         self.db
             .with_conn(move |c| {
                 c.execute("DELETE FROM workflow_runs WHERE run_id = ?", [id_s])
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
                 Ok(())
+            })
+            .await
+    }
+
+    async fn purge_runs(&self, workflow_id: Uuid) -> Result<Vec<Uuid>, AcsError> {
+        // Delete every non-Running run for the workflow in one transaction and
+        // return the deleted run ids (so the caller can clean up log files).
+        // Running runs are skipped. Cost-ledger rows are NOT touched.
+        let wf_s = workflow_id.to_string();
+        self.db
+            .with_conn(move |c| {
+                let tx = c.transaction().map_err(|e| {
+                    AcsError::Storage(format!("Failed to start transaction: {}", e))
+                })?;
+
+                let deleted: Vec<Uuid> = {
+                    let mut stmt = tx
+                        .prepare(
+                            "SELECT run_id FROM workflow_runs \
+                             WHERE workflow_id = ?1 AND status != 'Running'",
+                        )
+                        .map_err(|e| AcsError::Storage(e.to_string()))?;
+                    let rows = stmt
+                        .query_map([&wf_s], |r| r.get::<_, String>(0))
+                        .map_err(|e| AcsError::Storage(e.to_string()))?;
+                    let mut ids = Vec::new();
+                    for r in rows {
+                        let id_s = r.map_err(|e| AcsError::Storage(e.to_string()))?;
+                        ids.push(Uuid::parse_str(&id_s).map_err(|e| {
+                            AcsError::Storage(format!("invalid run_id '{}': {}", id_s, e))
+                        })?);
+                    }
+                    ids
+                };
+
+                tx.execute(
+                    "DELETE FROM workflow_runs WHERE workflow_id = ?1 AND status != 'Running'",
+                    [&wf_s],
+                )
+                .map_err(|e| {
+                    AcsError::Storage(format!("bulk DELETE workflow_runs failed: {}", e))
+                })?;
+
+                tx.commit()
+                    .map_err(|e| AcsError::Storage(format!("COMMIT failed: {}", e)))?;
+                Ok(deleted)
+            })
+            .await
+    }
+
+    async fn list_ledger_workflows(&self) -> Result<Vec<(Uuid, String)>, AcsError> {
+        // Distinct workflow ids present in the cost ledger, each paired with
+        // the workflow name recorded on its most recent run (run_ids are
+        // UUIDv7, so MAX(run_id) is the latest).
+        self.db
+            .with_conn(move |c| {
+                let mut stmt = c
+                    .prepare(
+                        "SELECT workflow_id, workflow_name FROM cost_ledger \
+                         WHERE run_id IN \
+                            (SELECT MAX(run_id) FROM cost_ledger GROUP BY workflow_id)",
+                    )
+                    .map_err(|e| AcsError::Storage(e.to_string()))?;
+                let rows = stmt
+                    .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+                    .map_err(|e| AcsError::Storage(e.to_string()))?;
+                let mut out = Vec::new();
+                for r in rows {
+                    let (id_s, name) = r.map_err(|e| AcsError::Storage(e.to_string()))?;
+                    let id = Uuid::parse_str(&id_s).map_err(|e| {
+                        AcsError::Storage(format!("invalid workflow_id '{}': {}", id_s, e))
+                    })?;
+                    out.push((id, name));
+                }
+                Ok(out)
             })
             .await
     }
@@ -363,7 +485,7 @@ impl WorkflowRunStore for SqliteWorkflowRunStore {
                           COALESCE(SUM(CASE WHEN finished_at >= ?2 THEN 1 END), 0)                      AS last_year_runs,
                           COALESCE(SUM(CASE WHEN finished_at >= ?2 THEN total_input_tokens END), 0)     AS last_year_input_tokens,
                           COALESCE(SUM(CASE WHEN finished_at >= ?2 THEN total_output_tokens END), 0)    AS last_year_output_tokens
-                        FROM workflow_runs
+                        FROM cost_ledger
                         WHERE workflow_id = ?3
                           AND status IN ('Completed', 'Failed', 'Killed')
                           AND finished_at IS NOT NULL
@@ -429,7 +551,7 @@ impl WorkflowRunStore for SqliteWorkflowRunStore {
                 let sql = if wf_id_s.is_some() {
                     "SELECT finished_at, status, total_cost_usd, \
                             total_input_tokens, total_output_tokens \
-                     FROM workflow_runs \
+                     FROM cost_ledger \
                      WHERE status IN ('Completed', 'Failed', 'Killed') \
                        AND finished_at IS NOT NULL \
                        AND finished_at >= ?1 \
@@ -439,7 +561,7 @@ impl WorkflowRunStore for SqliteWorkflowRunStore {
                 } else {
                     "SELECT finished_at, status, total_cost_usd, \
                             total_input_tokens, total_output_tokens \
-                     FROM workflow_runs \
+                     FROM cost_ledger \
                      WHERE status IN ('Completed', 'Failed', 'Killed') \
                        AND finished_at IS NOT NULL \
                        AND finished_at >= ?1 \
@@ -889,6 +1011,7 @@ mod tests {
         let status = status.to_string();
         let finished_at = finished_at.map(|s| s.to_string());
 
+        let wf_name = workflow.name.clone();
         db_conn
             .with_conn(move |c| {
                 c.execute(
@@ -911,6 +1034,29 @@ mod tests {
                     ],
                 )
                 .map_err(|e| AcsError::Storage(e.to_string()))?;
+                // Mirror the production invariant: every terminal run also has
+                // a cost-ledger row (cost queries aggregate from cost_ledger).
+                if status != "Running" {
+                    c.execute(
+                        "INSERT INTO cost_ledger (
+                            run_id, workflow_id, workflow_name, started_at,
+                            finished_at, status, total_cost_usd,
+                            total_input_tokens, total_output_tokens
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                        params![
+                            run_id,
+                            wf_id,
+                            wf_name,
+                            started_at,
+                            finished_at,
+                            status,
+                            cost_usd,
+                            input_tokens,
+                            output_tokens,
+                        ],
+                    )
+                    .map_err(|e| AcsError::Storage(e.to_string()))?;
+                }
                 Ok(())
             })
             .await
@@ -965,11 +1111,11 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-null-mix").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
+        let recent = (Utc::now() - chrono::Duration::days(10)).to_rfc3339();
         // run with cost 0.5
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), Some(0.5)).await;
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), Some(0.5)).await;
         // run with null cost — counted but not summed
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), None).await;
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), None).await;
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
             .await
@@ -985,10 +1131,10 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-statuses").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
-        seed_raw_run(&run_store, &wf, "Failed", Some(recent), Some(0.1)).await;
-        seed_raw_run(&run_store, &wf, "Killed", Some(recent), Some(0.2)).await;
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), Some(0.3)).await;
+        let recent = (Utc::now() - chrono::Duration::days(10)).to_rfc3339();
+        seed_raw_run(&run_store, &wf, "Failed", Some(&recent), Some(0.1)).await;
+        seed_raw_run(&run_store, &wf, "Killed", Some(&recent), Some(0.2)).await;
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), Some(0.3)).await;
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
             .await
@@ -1142,8 +1288,8 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-utc").await;
         let utc_tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T00:00:00+00:00";
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), Some(1.5)).await;
+        let recent = (Utc::now() - chrono::Duration::days(10)).to_rfc3339();
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), Some(1.5)).await;
         let summary = run_store
             .cost_summary_for(wf.id, &utc_tz)
             .await
@@ -1452,7 +1598,7 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "tok-summary").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
+        let recent = (Utc::now() - chrono::Duration::days(10)).to_rfc3339();
 
         // Seed three runs: Completed (100 in / 50 out), Failed (200 in / 80 out),
         // Killed (300 in / 120 out).
@@ -1460,15 +1606,24 @@ mod tests {
             &run_store,
             &wf,
             "Completed",
-            Some(recent),
+            Some(&recent),
             Some(0.1),
             100,
             50,
         )
         .await;
-        seed_raw_run_with_tokens(&run_store, &wf, "Failed", Some(recent), Some(0.2), 200, 80).await;
-        seed_raw_run_with_tokens(&run_store, &wf, "Killed", Some(recent), Some(0.3), 300, 120)
+        seed_raw_run_with_tokens(&run_store, &wf, "Failed", Some(&recent), Some(0.2), 200, 80)
             .await;
+        seed_raw_run_with_tokens(
+            &run_store,
+            &wf,
+            "Killed",
+            Some(&recent),
+            Some(0.3),
+            300,
+            120,
+        )
+        .await;
 
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
@@ -1674,5 +1829,229 @@ mod tests {
         // Aggregation correct.
         assert_eq!(buckets[0].runs_completed, 2);
         assert_eq!(buckets[2].runs_completed, 2);
+    }
+
+    // ── Cost ledger (ACS-25) ─────────────────────────────────────────────────
+
+    /// Count ledger rows for a run id directly via SQL.
+    async fn ledger_row_count(store: &SqliteWorkflowRunStore, run_id: Uuid) -> i64 {
+        let id_s = run_id.to_string();
+        store
+            .db
+            .clone()
+            .with_conn(move |c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM cost_ledger WHERE run_id = ?",
+                    [&id_s],
+                    |r| r.get(0),
+                )
+                .map_err(|e| AcsError::Storage(e.to_string()))
+            })
+            .await
+            .expect("count ledger rows")
+    }
+
+    #[tokio::test]
+    async fn test_terminal_run_writes_ledger_row() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let parent = seed_workflow(&wf_store, "ledger-write").await;
+        let run = make_completed_run(&parent);
+        let run_id = run.run_id;
+        run_store.create_run(run).await.expect("create");
+        assert_eq!(
+            ledger_row_count(&run_store, run_id).await,
+            1,
+            "terminal run must produce a cost_ledger row"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_running_run_does_not_write_ledger_row() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let parent = seed_workflow(&wf_store, "ledger-running").await;
+        let run = make_run(&parent); // status = Running
+        let run_id = run.run_id;
+        run_store.create_run(run.clone()).await.expect("create");
+        assert_eq!(
+            ledger_row_count(&run_store, run_id).await,
+            0,
+            "Running runs must not appear in the ledger"
+        );
+
+        // Finalizing the same run (Running → Completed) writes the row.
+        let mut finished = run;
+        finished.status = RunStatus::Completed;
+        finished.finished_at = Some(Utc::now());
+        finished.total_cost_usd = Some(0.42);
+        run_store.update_run(&finished).await.expect("finalize");
+        assert_eq!(
+            ledger_row_count(&run_store, run_id).await,
+            1,
+            "finalized run must produce a cost_ledger row"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ledger_rows_survive_run_deletion() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let wf = seed_workflow(&wf_store, "ledger-survives-run-del").await;
+        let tz: Tz = "UTC".parse().unwrap();
+        let run = make_completed_run(&wf);
+        let run_id = run.run_id;
+        run_store.create_run(run).await.expect("create");
+
+        run_store.delete_run(run_id).await.expect("delete run");
+        assert!(run_store.get_run(run_id).await.expect("get").is_none());
+
+        // Ledger row is untouched, so cost analytics still count the run.
+        assert_eq!(ledger_row_count(&run_store, run_id).await, 1);
+        let summary = run_store
+            .cost_summary_for(wf.id, &tz)
+            .await
+            .expect("cost_summary");
+        assert_eq!(summary.last_30_days_runs, 1);
+        assert!((summary.last_30_days_total_usd - 0.001).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn test_ledger_rows_survive_workflow_deletion() {
+        use crate::storage::workflows::WorkflowStore;
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let wf = seed_workflow(&wf_store, "ledger-survives-wf-del").await;
+        let tz: Tz = "UTC".parse().unwrap();
+        let run = make_completed_run(&wf);
+        run_store.create_run(run).await.expect("create");
+
+        wf_store
+            .delete_workflow(wf.id)
+            .await
+            .expect("cascade delete workflow with run history");
+        assert!(wf_store.get_workflow(wf.id).await.expect("get").is_none());
+        assert_eq!(
+            run_store.count_runs(wf.id).await.expect("count"),
+            0,
+            "runs must be cascaded away"
+        );
+
+        // The deleted workflow's cost history still aggregates from the ledger.
+        let summary = run_store
+            .cost_summary_for(wf.id, &tz)
+            .await
+            .expect("cost_summary");
+        assert_eq!(summary.last_30_days_runs, 1);
+        assert!((summary.last_30_days_total_usd - 0.001).abs() < 1e-9);
+
+        // ...and the ledger still knows the workflow's name.
+        let ledger = run_store
+            .list_ledger_workflows()
+            .await
+            .expect("list_ledger_workflows");
+        assert!(ledger.contains(&(wf.id, "ledger-survives-wf-del".to_string())));
+    }
+
+    // ── purge_runs (ACS-25) ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_purge_runs_deletes_non_running_and_returns_ids() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let wf = seed_workflow(&wf_store, "purge-basic").await;
+
+        let mut terminal_ids = Vec::new();
+        for _ in 0..3 {
+            let run = make_completed_run(&wf);
+            terminal_ids.push(run.run_id);
+            run_store.create_run(run).await.expect("create");
+        }
+
+        let deleted = run_store.purge_runs(wf.id).await.expect("purge");
+        assert_eq!(deleted.len(), 3);
+        let mut deleted_sorted = deleted.clone();
+        deleted_sorted.sort();
+        terminal_ids.sort();
+        assert_eq!(deleted_sorted, terminal_ids);
+        assert_eq!(run_store.count_runs(wf.id).await.expect("count"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_purge_runs_skips_running_runs() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let wf = seed_workflow(&wf_store, "purge-skips-running").await;
+
+        let running = make_run(&wf); // status = Running
+        let running_id = running.run_id;
+        run_store.create_run(running).await.expect("create running");
+        run_store
+            .create_run(make_completed_run(&wf))
+            .await
+            .expect("create completed");
+
+        let deleted = run_store.purge_runs(wf.id).await.expect("purge");
+        assert_eq!(deleted.len(), 1, "only the terminal run is purged");
+        assert!(!deleted.contains(&running_id));
+        assert!(
+            run_store.get_run(running_id).await.expect("get").is_some(),
+            "the Running run must survive the purge"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_purge_runs_no_runs_returns_empty() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let wf = seed_workflow(&wf_store, "purge-empty").await;
+        let deleted = run_store.purge_runs(wf.id).await.expect("purge");
+        assert!(deleted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_purge_runs_leaves_ledger_intact() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let wf = seed_workflow(&wf_store, "purge-keeps-ledger").await;
+        let tz: Tz = "UTC".parse().unwrap();
+        run_store
+            .create_run(make_completed_run(&wf))
+            .await
+            .expect("create");
+
+        run_store.purge_runs(wf.id).await.expect("purge");
+
+        let summary = run_store
+            .cost_summary_for(wf.id, &tz)
+            .await
+            .expect("cost_summary");
+        assert_eq!(
+            summary.last_30_days_runs, 1,
+            "purged runs must still count in cost analytics via the ledger"
+        );
+    }
+
+    // ── list_ledger_workflows ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_list_ledger_workflows_uses_latest_name() {
+        let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
+        let wf = seed_workflow(&wf_store, "ledger-name-v1").await;
+
+        // First terminal run under the original name.
+        run_store
+            .create_run(make_completed_run(&wf))
+            .await
+            .expect("create 1");
+
+        // Rename the workflow, then record a later terminal run whose snapshot
+        // carries the new name.
+        let mut renamed = wf.clone();
+        renamed.name = "ledger-name-v2".to_string();
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        run_store
+            .create_run(make_completed_run(&renamed))
+            .await
+            .expect("create 2");
+
+        let ledger = run_store
+            .list_ledger_workflows()
+            .await
+            .expect("list_ledger_workflows");
+        assert_eq!(ledger.len(), 1);
+        assert_eq!(ledger[0], (wf.id, "ledger-name-v2".to_string()));
     }
 }

--- a/acs/src/storage/sqlite/workflows.rs
+++ b/acs/src/storage/sqlite/workflows.rs
@@ -359,17 +359,54 @@ impl WorkflowStore for SqliteWorkflowStore {
     }
 
     async fn delete_workflow(&self, id: Uuid) -> Result<()> {
+        // Transactional cascade: refuse when the workflow has an active run,
+        // otherwise delete the run history and the workflow row atomically.
+        // Cost-ledger rows are intentionally left behind — cost analytics must
+        // survive workflow deletion.
         self.db
             .with_conn(move |c| {
-                let n = c
-                    .execute("DELETE FROM workflows WHERE id = ?", [id.to_string()])
+                let id_s = id.to_string();
+                let tx = c.transaction().map_err(|e| {
+                    AcsError::Storage(format!("Failed to start transaction: {}", e))
+                })?;
+
+                let running: i64 = tx
+                    .query_row(
+                        "SELECT COUNT(*) FROM workflow_runs \
+                         WHERE workflow_id = ?1 AND status = 'Running'",
+                        [&id_s],
+                        |r| r.get(0),
+                    )
+                    .map_err(|e| AcsError::Storage(e.to_string()))?;
+                if running > 0 {
+                    return Err(AcsError::Conflict(format!(
+                        "Workflow '{}' has {} running run(s). Kill them (POST /api/runs/{{run_id}}/kill) \
+                         or wait for them to finish before deleting the workflow.",
+                        id, running
+                    )));
+                }
+
+                // Explicit cascade (the FK's ON DELETE CASCADE is defense in
+                // depth on top of this).
+                tx.execute(
+                    "DELETE FROM workflow_runs WHERE workflow_id = ?",
+                    [&id_s],
+                )
+                .map_err(|e| AcsError::Storage(format!("DELETE workflow_runs failed: {}", e)))?;
+
+                let n = tx
+                    .execute("DELETE FROM workflows WHERE id = ?", [&id_s])
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
                 if n == 0 {
+                    // Dropping the transaction rolls back the run deletion.
                     return Err(AcsError::NotFound(format!(
                         "Workflow with id '{}' not found",
                         id
                     )));
                 }
+
+                tx.commit()
+                    .map_err(|e| AcsError::Storage(format!("COMMIT failed: {}", e)))?;
                 Ok(())
             })
             .await?;
@@ -916,6 +953,43 @@ mod tests {
 
     // ── Delete ────────────────────────────────────────────────────────────────
 
+    /// Build a paired workflow store + run store sharing one in-memory DB, for
+    /// deletion tests that need run history.
+    fn paired_stores() -> (
+        SqliteWorkflowStore,
+        crate::storage::sqlite::SqliteWorkflowRunStore,
+    ) {
+        let db = crate::storage::sqlite::init_in_memory_db().expect("init in-memory db");
+        (
+            SqliteWorkflowStore::new(&db),
+            crate::storage::sqlite::SqliteWorkflowRunStore::new(&db),
+        )
+    }
+
+    /// Build a run for `parent` with the given status.
+    fn make_run_with_status(
+        parent: &Workflow,
+        status: RunStatus,
+    ) -> crate::models::workflow::WorkflowRun {
+        let now = Utc::now();
+        let terminal = status != RunStatus::Running;
+        crate::models::workflow::WorkflowRun {
+            run_id: Uuid::now_v7(),
+            workflow_id: parent.id,
+            workflow_version: parent.version,
+            workflow_snapshot: parent.clone(),
+            started_at: now,
+            finished_at: if terminal { Some(now) } else { None },
+            status,
+            trigger_input: None,
+            steps: vec![],
+            total_cost_usd: if terminal { Some(0.01) } else { None },
+            total_duration_ms: None,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+        }
+    }
+
     #[tokio::test]
     async fn test_delete_then_get_returns_none() {
         let store = SqliteWorkflowStore::in_memory_for_tests();
@@ -937,6 +1011,62 @@ mod tests {
             .expect_err("must error");
         let acs = err.downcast_ref::<AcsError>().expect("must be AcsError");
         assert!(matches!(acs, AcsError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_delete_workflow_with_terminal_runs_cascades() {
+        use crate::storage::workflow_runs::WorkflowRunStore;
+        let (store, run_store) = paired_stores();
+        let created = store
+            .create_workflow(minimal_new_workflow("del-cascade"))
+            .await
+            .expect("create");
+        for status in [RunStatus::Completed, RunStatus::Failed, RunStatus::Killed] {
+            run_store
+                .create_run(make_run_with_status(&created, status))
+                .await
+                .expect("create run");
+        }
+
+        store
+            .delete_workflow(created.id)
+            .await
+            .expect("delete must succeed despite run history");
+
+        assert!(store.get_workflow(created.id).await.expect("get").is_none());
+        assert_eq!(
+            run_store.count_runs(created.id).await.expect("count"),
+            0,
+            "run history must be deleted with the workflow"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_workflow_with_running_run_returns_conflict() {
+        use crate::storage::workflow_runs::WorkflowRunStore;
+        let (store, run_store) = paired_stores();
+        let created = store
+            .create_workflow(minimal_new_workflow("del-running-guard"))
+            .await
+            .expect("create");
+        let running = make_run_with_status(&created, RunStatus::Running);
+        let running_id = running.run_id;
+        run_store.create_run(running).await.expect("create run");
+
+        let err = store
+            .delete_workflow(created.id)
+            .await
+            .expect_err("delete must be refused while a run is active");
+        let acs = err.downcast_ref::<AcsError>().expect("must be AcsError");
+        assert!(matches!(acs, AcsError::Conflict(_)), "got: {:?}", acs);
+
+        // Nothing was deleted.
+        assert!(store.get_workflow(created.id).await.expect("get").is_some());
+        assert!(run_store
+            .get_run(running_id)
+            .await
+            .expect("get run")
+            .is_some());
     }
 
     // ── List ──────────────────────────────────────────────────────────────────

--- a/acs/src/storage/workflow_runs.rs
+++ b/acs/src/storage/workflow_runs.rs
@@ -42,8 +42,18 @@ pub trait WorkflowRunStore: Send + Sync {
     /// Total count of runs across all workflows.
     async fn count_all_runs(&self) -> Result<usize, AcsError>;
 
-    /// Delete a run record. Best-effort.
+    /// Delete a run record. Best-effort. Cost-ledger rows are untouched.
     async fn delete_run(&self, run_id: Uuid) -> Result<(), AcsError>;
+
+    /// Delete every non-Running run for the workflow in one transaction and
+    /// return the deleted run ids. Running runs are skipped. Cost-ledger rows
+    /// are untouched.
+    async fn purge_runs(&self, workflow_id: Uuid) -> Result<Vec<Uuid>, AcsError>;
+
+    /// Distinct `(workflow_id, workflow_name)` pairs present in the durable
+    /// cost ledger, using the name recorded on each workflow's most recent
+    /// terminal run. Includes workflows that have since been deleted.
+    async fn list_ledger_workflows(&self) -> Result<Vec<(Uuid, String)>, AcsError>;
 
     /// Compute cost aggregates for a workflow over the last 30 days and last
     /// year, using calendar-day boundaries in `display_tz`.

--- a/acs/src/workflow/executor.rs
+++ b/acs/src/workflow/executor.rs
@@ -1460,6 +1460,11 @@ mod tests {
     // are acceptable here; what matters is that the step dispatched.
 
     #[tokio::test]
+    #[ignore = "spawns a REAL `claude -p \"do something\" --dangerously-skip-permissions` \
+                session when the CLI is on PATH: slow, costs API spend, and the spawned \
+                agent can run `cargo test` in this repo and fork-bomb more sessions. \
+                Run explicitly with `cargo test -- --ignored` on a machine without the \
+                CLI, or rewrite with an injected mock spawner (see steps::agent tests)."]
     async fn test_executor_agent_step_dispatched() {
         use crate::models::workflow::{AgentStep, AgentType};
 

--- a/acs/tests/workflow_api_tests.rs
+++ b/acs/tests/workflow_api_tests.rs
@@ -1947,7 +1947,7 @@ async fn test_cost_summary_cache_evicted_on_workflow_delete() {
     let wf_id = uuid::Uuid::parse_str(wf_id_str).unwrap();
     let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
 
-    let run_id = insert_terminal_run(
+    let _run_id = insert_terminal_run(
         &run_store,
         wf_id,
         &wf,
@@ -1968,12 +1968,8 @@ async fn test_cost_summary_cache_evicted_on_workflow_delete() {
         .unwrap();
     assert_eq!(resp1["cost_summary"]["last_30_days_runs"], 1);
 
-    // Delete the child run first to satisfy the workflow_runs.workflow_id FK,
-    // then DELETE the workflow.
-    run_store
-        .delete_run(run_id)
-        .await
-        .expect("delete child run");
+    // DELETE the workflow directly — since ACS-25 the delete cascades into
+    // workflow_runs, so the child run no longer needs to be removed first.
     let del_resp = client
         .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
         .send()
@@ -2023,6 +2019,416 @@ async fn test_cost_summary_cache_evicted_on_workflow_delete() {
         resp2["cost_summary"]["last_30_days_runs"], 0,
         "recreated workflow should have zero runs in cost_summary"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Workflow deletion + run purge tests (ACS-25)
+// ---------------------------------------------------------------------------
+
+/// D-1. DELETE /api/workflows/{id} succeeds (204) for a workflow WITH run
+///      history, cascades the runs away, and removes the log directory.
+#[tokio::test]
+async fn test_delete_workflow_with_run_history_cascades() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("del-history-wf")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap();
+    let wf_id = uuid::Uuid::parse_str(wf_id_str).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+
+    // Two terminal runs + a fake on-disk log dir.
+    let run_a = insert_terminal_run(
+        &run_store,
+        wf_id,
+        &wf,
+        RunStatus::Completed,
+        Utc::now() - Duration::days(1),
+        Some(0.10),
+    )
+    .await;
+    let run_b = insert_terminal_run(
+        &run_store,
+        wf_id,
+        &wf,
+        RunStatus::Failed,
+        Utc::now() - Duration::hours(1),
+        None,
+    )
+    .await;
+    let log_dir = tmp.path().join("logs").join(wf_id_str);
+    tokio::fs::create_dir_all(&log_dir).await.unwrap();
+    tokio::fs::write(log_dir.join(format!("{}.log", run_a)), b"log-a")
+        .await
+        .unwrap();
+
+    // This is the exact scenario that used to 500 with
+    // "FOREIGN KEY constraint failed".
+    let del_resp = client
+        .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("DELETE workflow");
+    assert_eq!(del_resp.status(), 204);
+
+    // Workflow gone.
+    let get_resp = client
+        .get(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("GET after delete");
+    assert_eq!(get_resp.status(), 404);
+
+    // Runs gone.
+    for run_id in [run_a, run_b] {
+        let run_resp = client
+            .get(format!("{}/api/runs/{}", base_url, run_id))
+            .send()
+            .await
+            .expect("GET run after delete");
+        assert_eq!(run_resp.status(), 404, "run {} must be gone", run_id);
+    }
+
+    // Log directory removed (best-effort, but expected to work here).
+    assert!(
+        !log_dir.exists(),
+        "log dir should be removed on workflow delete"
+    );
+}
+
+/// D-2. DELETE /api/workflows/{id} with a Running run → 409 Conflict and
+///      nothing is deleted.
+#[tokio::test]
+async fn test_delete_workflow_with_running_run_returns_409() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("del-running-wf")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap();
+    let wf_id = uuid::Uuid::parse_str(wf_id_str).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+
+    let running_id = insert_running_run(&run_store, wf_id, &wf).await;
+
+    let del_resp = client
+        .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("DELETE workflow");
+    assert_eq!(del_resp.status(), 409);
+    let body: serde_json::Value = del_resp.json().await.unwrap();
+    assert_eq!(body["error"], "conflict");
+    assert!(
+        body["message"].as_str().unwrap().contains("running"),
+        "message should explain the active-run conflict: {}",
+        body["message"]
+    );
+
+    // Workflow and run both survive.
+    let get_resp = client
+        .get(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("GET after refused delete");
+    assert_eq!(get_resp.status(), 200);
+    assert!(run_store.get_run(running_id).await.unwrap().is_some());
+}
+
+/// D-3. DELETE /api/runs/{run_id}: 204 on success (log file removed), then
+///      404 on repeat; 404 for unknown ids.
+#[tokio::test]
+async fn test_delete_run_endpoint() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("del-run-wf")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id = uuid::Uuid::parse_str(created["id"].as_str().unwrap()).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+
+    let run_id = insert_terminal_run(
+        &run_store,
+        wf_id,
+        &wf,
+        RunStatus::Completed,
+        Utc::now() - Duration::hours(1),
+        Some(0.05),
+    )
+    .await;
+    let log_dir = tmp.path().join("logs").join(wf_id.to_string());
+    tokio::fs::create_dir_all(&log_dir).await.unwrap();
+    let log_path = log_dir.join(format!("{}.log", run_id));
+    tokio::fs::write(&log_path, b"run log").await.unwrap();
+
+    // Delete → 204, run + log file gone.
+    let del_resp = client
+        .delete(format!("{}/api/runs/{}", base_url, run_id))
+        .send()
+        .await
+        .expect("DELETE run");
+    assert_eq!(del_resp.status(), 204);
+    assert!(run_store.get_run(run_id).await.unwrap().is_none());
+    assert!(!log_path.exists(), "run log file should be removed");
+
+    // Repeat delete → 404.
+    let del_again = client
+        .delete(format!("{}/api/runs/{}", base_url, run_id))
+        .send()
+        .await
+        .expect("DELETE run again");
+    assert_eq!(del_again.status(), 404);
+
+    // Unknown id → 404.
+    let unknown = client
+        .delete(format!("{}/api/runs/{}", base_url, uuid::Uuid::now_v7()))
+        .send()
+        .await
+        .expect("DELETE unknown run");
+    assert_eq!(unknown.status(), 404);
+}
+
+/// D-4. DELETE /api/runs/{run_id} for a Running run → 409, run survives.
+#[tokio::test]
+async fn test_delete_running_run_returns_409() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("del-run-running-wf")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id = uuid::Uuid::parse_str(created["id"].as_str().unwrap()).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+    let running_id = insert_running_run(&run_store, wf_id, &wf).await;
+
+    let del_resp = client
+        .delete(format!("{}/api/runs/{}", base_url, running_id))
+        .send()
+        .await
+        .expect("DELETE running run");
+    assert_eq!(del_resp.status(), 409);
+    let body: serde_json::Value = del_resp.json().await.unwrap();
+    assert_eq!(body["error"], "conflict");
+    assert!(run_store.get_run(running_id).await.unwrap().is_some());
+}
+
+/// D-5. DELETE /api/workflows/{id}/runs bulk-purges non-Running runs, returns
+///      {"deleted": n}, skips Running runs, and leaves the workflow intact.
+#[tokio::test]
+async fn test_purge_workflow_runs_endpoint() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("purge-runs-wf")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap();
+    let wf_id = uuid::Uuid::parse_str(wf_id_str).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+
+    // 3 terminal runs + 1 running run.
+    for status in [RunStatus::Completed, RunStatus::Failed, RunStatus::Killed] {
+        insert_terminal_run(
+            &run_store,
+            wf_id,
+            &wf,
+            status,
+            Utc::now() - Duration::hours(2),
+            Some(0.01),
+        )
+        .await;
+    }
+    let running_id = insert_running_run(&run_store, wf_id, &wf).await;
+
+    let purge_resp = client
+        .delete(format!("{}/api/workflows/{}/runs", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("DELETE /api/workflows/{id}/runs");
+    assert_eq!(purge_resp.status(), 200);
+    let body: serde_json::Value = purge_resp.json().await.unwrap();
+    assert_eq!(body["deleted"], 3, "three terminal runs purged");
+
+    // The Running run survives; the workflow itself is untouched.
+    assert!(run_store.get_run(running_id).await.unwrap().is_some());
+    assert_eq!(run_store.count_runs(wf_id).await.unwrap(), 1);
+    let get_resp = client
+        .get(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("GET workflow after purge");
+    assert_eq!(get_resp.status(), 200);
+
+    // Purging again deletes nothing new.
+    let purge_again: serde_json::Value = client
+        .delete(format!("{}/api/workflows/{}/runs", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("second purge")
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(purge_again["deleted"], 0);
+}
+
+/// D-6. Cost endpoints still include a deleted workflow's spend, served from
+///      the durable cost ledger with the stored workflow name.
+#[tokio::test]
+async fn test_cost_endpoints_include_deleted_workflow_costs() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("cost-survives-delete-wf")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap().to_string();
+    let wf_id = uuid::Uuid::parse_str(&wf_id_str).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+
+    insert_terminal_run(
+        &run_store,
+        wf_id,
+        &wf,
+        RunStatus::Completed,
+        Utc::now() - Duration::days(1),
+        Some(1.25),
+    )
+    .await;
+
+    // Delete the workflow (cascades its runs).
+    let del_resp = client
+        .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("DELETE workflow");
+    assert_eq!(del_resp.status(), 204);
+
+    // The list endpoint still carries an entry for the deleted workflow,
+    // with the ledger's stored name and the historical spend.
+    let list: serde_json::Value = client
+        .get(format!("{}/api/cost/workflows", base_url))
+        .send()
+        .await
+        .expect("GET /api/cost/workflows")
+        .json()
+        .await
+        .unwrap();
+    let entry = list["workflows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["workflow_id"] == wf_id_str.as_str())
+        .expect("deleted workflow must still appear in the cost list");
+    assert_eq!(entry["workflow_name"], "cost-survives-delete-wf");
+    assert_eq!(entry["cost_summary"]["last_30_days_runs"], 1);
+    let entry_total = entry["cost_summary"]["last_30_days_total_usd"]
+        .as_f64()
+        .unwrap();
+    assert!((entry_total - 1.25).abs() < 1e-9);
+
+    // The system aggregate includes the deleted workflow's spend.
+    let sys_total = list["system_cost_summary"]["last_30_days_total_usd"]
+        .as_f64()
+        .unwrap();
+    assert!(
+        sys_total >= 1.25 - 1e-9,
+        "system total should include deleted-workflow costs, got {}",
+        sys_total
+    );
+
+    // The per-workflow cost endpoint also still resolves.
+    let per_wf: serde_json::Value = client
+        .get(format!("{}/api/cost/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("GET /api/cost/workflows/{id} after delete")
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(per_wf["workflow_name"], "cost-survives-delete-wf");
+    assert_eq!(per_wf["cost_summary"]["last_30_days_runs"], 1);
 }
 
 // ---------------------------------------------------------------------------

--- a/acs/web/openapi.yaml
+++ b/acs/web/openapi.yaml
@@ -7,7 +7,7 @@ info:
     ACS is a multi-step workflow scheduler with a built-in HTTP API and web UI.
     Workflows can be identified by either their UUID or their unique name in all
     endpoints that accept an `{id}` path parameter.
-  version: "4.2.13"
+  version: "4.2.14"
   license:
     name: MIT
 
@@ -49,7 +49,7 @@ paths:
                 uptime_seconds: 3600
                 active_jobs: 5
                 total_jobs: 8
-                version: "4.2.13"
+                version: "4.2.14"
                 data_dir: "C:\\Users\\J\\AppData\\Local\\acs\\data"
                 service:
                   registered: true
@@ -268,22 +268,39 @@ paths:
 
     delete:
       operationId: deleteWorkflow
-      summary: Delete a workflow
+      summary: Delete a workflow and its run history
       description: |
-        Deletes a workflow by ID or name. If the workflow has an active run it
-        will be killed before deletion. Returns 204 on success with no body.
+        Deletes a workflow by ID or name **together with its entire run
+        history** in one transaction (v4.2.14), then removes the workflow's
+        log directory best-effort. Refused with 409 Conflict while the
+        workflow has any Running run — kill the run(s) via
+        `POST /api/runs/{run_id}/kill` or wait for them to finish.
+
+        Cost/token history is retained: terminal runs are mirrored into the
+        durable `cost_ledger` table, so the deleted workflow's spend still
+        appears in the cost analytics endpoints. Returns 204 on success with
+        no body.
       tags: [Workflows]
       parameters:
         - $ref: "#/components/parameters/WorkflowId"
       responses:
         "204":
-          description: Workflow deleted (no content)
+          description: Workflow and its runs deleted (no content)
         "404":
           description: Workflow not found
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: The workflow has at least one Running run.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: conflict
+                message: "Workflow '0192a3b4-c5d6-7e8f-9a0b-1c2d3e4f5678' has 1 running run(s). Kill them (POST /api/runs/{run_id}/kill) or wait for them to finish before deleting the workflow."
         "500":
           description: Internal server error
           content:
@@ -485,6 +502,46 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+    delete:
+      operationId: purgeWorkflowRuns
+      summary: Bulk-purge a workflow's run history
+      description: |
+        Deletes every **non-Running** run record for the workflow along with
+        each run's on-disk log file (best-effort). Running runs are skipped
+        and survive the purge; the workflow definition itself is untouched.
+        Cost/token history is retained in the durable `cost_ledger`, so cost
+        analytics are unaffected. Works whether or not the workflow currently
+        has Running runs (v4.2.14).
+      tags: [WorkflowRuns]
+      parameters:
+        - $ref: "#/components/parameters/WorkflowId"
+      responses:
+        "200":
+          description: Purge complete.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [deleted]
+                properties:
+                  deleted:
+                    type: integer
+                    description: Number of run records deleted (skipped Running runs are not counted).
+              example:
+                deleted: 42
+        "404":
+          description: Workflow not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   # -------------------------------------------------------------------------
   # Workflow Runs
   # -------------------------------------------------------------------------
@@ -584,6 +641,55 @@ paths:
               example:
                 error: not_found
                 message: "Run with id '0192a3b4-dddd-7e8f-9a0b-1c2d3e4f5678' not found"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      operationId: deleteWorkflowRun
+      summary: Delete a workflow run
+      description: |
+        Deletes a single run record and removes its on-disk log file
+        (best-effort). Refused with 409 Conflict while the run is Running —
+        kill it via `POST /api/runs/{run_id}/kill` or wait for it to finish.
+        Cost/token history is retained in the durable `cost_ledger`, so cost
+        analytics are unaffected (v4.2.14).
+      tags: [WorkflowRuns]
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          description: UUID of the workflow run to delete.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Run deleted (no content)
+        "400":
+          description: run_id is not a valid UUID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Run not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: The run is still Running.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: conflict
+                message: "Run '0192a3b4-dddd-7e8f-9a0b-1c2d3e4f5678' is still running. Kill it (POST /api/runs/0192a3b4-dddd-7e8f-9a0b-1c2d3e4f5678/kill) or wait for it to finish before deleting it."
         "500":
           description: Internal server error
           content:
@@ -775,6 +881,11 @@ paths:
         Returns cost summaries for all workflows plus a system-wide aggregate.
         Supports optional `days`, `since`, and `until` query parameters to
         control the daily-buckets window (default last 30 days).
+
+        Since v4.2.14 aggregates are computed from the durable `cost_ledger`,
+        so deleted workflows with historical spend are included (named via the
+        ledger's stored `workflow_name`) and count toward
+        `system_cost_summary`.
       tags: [Cost]
       parameters:
         - name: days
@@ -851,6 +962,11 @@ paths:
         Returns the cost summary for a specific workflow by UUID. Supports
         optional `days`, `since`, and `until` query parameters to control the
         daily-buckets window (default last 30 days).
+
+        Since v4.2.14 deleted workflows remain queryable while they have
+        spend in the durable `cost_ledger`; their `workflow_name` is served
+        from the ledger. 404 is returned only when the UUID matches neither a
+        live workflow nor any ledger history.
       tags: [Cost]
       parameters:
         - name: id
@@ -1060,7 +1176,7 @@ components:
         version:
           type: string
           description: Daemon version string.
-          example: "4.2.13"
+          example: "4.2.14"
         data_dir:
           type: string
           description: Filesystem path to the data directory.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,8 +26,10 @@ All request and response bodies use JSON (`Content-Type: application/json`) unle
   - [DELETE /api/workflows/{id}/favorite](#delete-apiworkflowsidfavorite)
   - [POST /api/workflows/{id}/trigger](#post-apiworkflowsidtrigger)
   - [GET /api/workflows/{id}/runs](#get-apiworkflowsidruns)
+  - [DELETE /api/workflows/{id}/runs](#delete-apiworkflowsidruns)
   - [GET /api/runs/recent](#get-apirunsrecent)
   - [GET /api/runs/{run_id}](#get-apirunsrun_id)
+  - [DELETE /api/runs/{run_id}](#delete-apirunsrun_id)
   - [POST /api/runs/{run_id}/kill](#post-apirunsrun_idkill)
   - [GET /api/runs/{run_id}/log](#get-apirunsrun_idlog)
   - [GET /api/events/workflows](#get-apieventsworkflows)
@@ -124,7 +126,7 @@ Returns daemon health status, including uptime, workflow counts, version, and pl
   "uptime_seconds": 3600,
   "active_jobs": 5,
   "total_jobs": 8,
-  "version": "4.2.13",
+  "version": "4.2.14",
   "data_dir": "/home/user/.local/share/agent-cron-scheduler",
   "service": {
     "registered": true,
@@ -317,7 +319,7 @@ Partially update an existing workflow. Only the fields you include in the reques
 
 ### DELETE /api/workflows/{id}
 
-Delete a workflow.
+Delete a workflow **and its entire run history** in one transaction (v4.2.14). Deletion is refused with `409 Conflict` while the workflow has any `Running` run — kill the run(s) or wait for them to finish first.
 
 **Path Parameters:**
 
@@ -331,11 +333,17 @@ Delete a workflow.
 
 | Status | Description |
 |--------|-------------|
-| 204 No Content | Workflow deleted. No response body. |
+| 204 No Content | Workflow and its runs deleted. No response body. |
 | 404 Not Found | Workflow not found. |
+| 409 Conflict | The workflow has at least one `Running` run. The message names the number of active runs and how to resolve the conflict. |
 | 500 Internal Server Error | Storage failure. |
 
-**Side effects:** Broadcasts a `WorkflowChanged` SSE event with `change_kind: "deleted"`.
+**Side effects:**
+
+- All `workflow_runs` rows for the workflow are deleted in the same transaction (before v4.2.14 this request failed with a 500 `FOREIGN KEY constraint failed` once the workflow had run history).
+- The workflow's on-disk log directory `<data_dir>/logs/<workflow_id>/` is removed best-effort (a failure is logged as a warning and does not fail the request).
+- Cost/token history is **retained**: the durable `cost_ledger` rows survive deletion, so the workflow's historical spend still appears in the [cost analytics endpoints](#cost-analytics-endpoints).
+- Broadcasts a `WorkflowChanged` SSE event with `change_kind: "deleted"`.
 
 ---
 
@@ -533,6 +541,40 @@ List execution runs for a specific workflow, with pagination. Returns latest-fir
 
 ---
 
+### DELETE /api/workflows/{id}/runs
+
+Bulk-purge the workflow's run history (v4.2.14). Deletes every **non-Running** run record for the workflow along with each run's on-disk log file (best-effort); `Running` runs are skipped and survive the purge. The workflow itself is untouched, and its cost/token history is retained in the durable `cost_ledger`, so cost analytics are unaffected.
+
+**Path Parameters:**
+
+| Parameter | Type   | Description             |
+|-----------|--------|-------------------------|
+| `id`      | string | Workflow UUID or name.  |
+
+**Request:** No body.
+
+**Response:**
+
+| Status | Description |
+|--------|-------------|
+| 200 OK | Purge complete. Returns the number of deleted runs. |
+| 404 Not Found | Workflow not found. |
+| 500 Internal Server Error | Storage failure. |
+
+```json
+{
+  "deleted": 42
+}
+```
+
+| Field     | Type    | Description                                        |
+|-----------|---------|----------------------------------------------------|
+| `deleted` | integer | Number of run records deleted (Running runs are not counted — they are skipped). |
+
+The endpoint works whether or not the workflow currently has `Running` runs; purging a workflow with no terminal runs returns `{"deleted": 0}`.
+
+---
+
 ### GET /api/runs/recent
 
 List recent execution runs across **all** workflows in a single chronologically-merged feed, latest-first. Each entry carries the same fields as a per-workflow run — including the embedded `workflow_snapshot` (which contains the workflow's `name`) — so consumers can render a mixed activity feed without additional lookups.
@@ -598,6 +640,30 @@ Retrieve a single run record with full step-level detail.
 | 500 Internal Server Error | Storage failure. |
 
 The response body is a [WorkflowRun](#workflowrun) object including the full `workflow_snapshot` (the complete workflow definition as it was at trigger time).
+
+---
+
+### DELETE /api/runs/{run_id}
+
+Delete a single run record (v4.2.14). Refused with `409 Conflict` while the run is `Running` — kill it first or wait for it to finish. On success the run's on-disk log file `<data_dir>/logs/<workflow_id>/<run_id>.log` is removed best-effort. The run's cost/token history is retained in the durable `cost_ledger`, so cost analytics are unaffected.
+
+**Path Parameters:**
+
+| Parameter | Type   | Description                            |
+|-----------|--------|----------------------------------------|
+| `run_id`  | string | The run UUID. Must be a valid UUID.    |
+
+**Request:** No body.
+
+**Response:**
+
+| Status | Description |
+|--------|-------------|
+| 204 No Content | Run deleted. No response body. |
+| 400 Bad Request | `run_id` is not a valid UUID. |
+| 404 Not Found | No run found for the given UUID. |
+| 409 Conflict | The run is still `Running`. Kill it (`POST /api/runs/{run_id}/kill`) or wait for it to finish. |
+| 500 Internal Server Error | Storage failure. |
 
 ---
 
@@ -795,6 +861,8 @@ No daemon logs available yet.
 
 All cost analytics are served from the `/api/cost/` namespace. These endpoints support the same query parameters for controlling the `daily_buckets` window.
 
+Since v4.2.14 all cost aggregates are computed from the durable `cost_ledger` table (see [docs/storage.md](storage.md)) instead of the raw `workflow_runs` rows. Because ledger rows have no foreign keys, cost and token history **survives deletion** of both workflows and individual runs: deleted workflows keep appearing in `GET /api/cost/workflows` (and stay queryable via `GET /api/cost/workflows/{id}`) with the workflow name stored in the ledger, and their spend remains part of `system_cost_summary`.
+
 ### Query Parameters (Cost Endpoints)
 
 | Parameter | Type    | Required | Default | Description |
@@ -815,7 +883,7 @@ All cost analytics are served from the `/api/cost/` namespace. These endpoints s
 
 ### GET /api/cost/workflows
 
-List cost analytics for all workflows.
+List cost analytics for all workflows — every live workflow plus any deleted workflow that still has spend recorded in the cost ledger (deleted entries use the ledger's stored `workflow_name`).
 
 **Request:** No body.
 
@@ -917,7 +985,7 @@ curl "http://127.0.0.1:8377/api/cost/workflows?since=2026-04-01&until=2026-05-01
 
 ### GET /api/cost/workflows/{id}
 
-Retrieve cost analytics for a single workflow.
+Retrieve cost analytics for a single workflow. Deleted workflows remain queryable as long as they have spend in the cost ledger; their `workflow_name` is served from the ledger (v4.2.14).
 
 **Path Parameters:**
 
@@ -935,7 +1003,7 @@ Retrieve cost analytics for a single workflow.
 |--------|-------------|
 | 200 OK | Returns a [CostWorkflowResponse](#costworkflowresponse) object. |
 | 400 Bad Request | Invalid path (non-UUID `{id}` rejected by Axum extraction) or invalid query parameter combination. |
-| 404 Not Found | UUID is well-formed but no workflow exists with that ID. |
+| 404 Not Found | UUID is well-formed but no workflow exists with that ID and the cost ledger has no history for it. |
 | 500 Internal Server Error | Storage failure. |
 
 ```json

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -125,7 +125,7 @@ CREATE TABLE workflow_runs (
     total_duration_ms   INTEGER,
     total_input_tokens  INTEGER NOT NULL DEFAULT 0,  -- added by m007 (v4.2.11)
     total_output_tokens INTEGER NOT NULL DEFAULT 0,  -- added by m007 (v4.2.11)
-    FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+    FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE  -- CASCADE added by m008 (v4.2.14)
 );
 
 CREATE INDEX idx_workflow_runs_workflow_id_finished_at
@@ -139,7 +139,54 @@ CREATE TABLE meta (
     key     TEXT PRIMARY KEY,
     value   TEXT NOT NULL
 );
+
+-- Durable cost ledger — added by m008 (v4.2.14)
+CREATE TABLE cost_ledger (
+    run_id              TEXT PRIMARY KEY,
+    workflow_id         TEXT NOT NULL,
+    workflow_name       TEXT NOT NULL,
+    started_at          TEXT NOT NULL,
+    finished_at         TEXT,
+    status              TEXT NOT NULL,
+    total_cost_usd      REAL,
+    total_input_tokens  INTEGER NOT NULL DEFAULT 0,
+    total_output_tokens INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_cost_ledger_workflow_id_finished_at
+    ON cost_ledger(workflow_id, finished_at);
+CREATE INDEX idx_cost_ledger_finished_at
+    ON cost_ledger(finished_at);
 ```
+
+### Cost ledger (`cost_ledger`)
+
+Added in v4.2.14 (ACS-25). An append-only "skinny" table with one row per
+**terminal** run (`Completed` / `Failed` / `Killed`) recording the run's
+cost and token bookkeeping plus the workflow name at the time of the run.
+
+Key properties:
+
+- **No foreign keys.** Rows deliberately do not reference `workflows` or
+  `workflow_runs`, so they survive deletion of both parents. Deleting a
+  workflow (which now cascades into `workflow_runs`), deleting a single run
+  (`DELETE /api/runs/{run_id}`), or bulk-purging runs
+  (`DELETE /api/workflows/{id}/runs`) never touches the ledger.
+- **Written at run persistence.** `upsert_ledger_row()` in
+  `storage/sqlite/workflow_runs.rs` runs alongside every run upsert
+  (`create_run` / `update_run`) and writes the ledger row as soon as the run
+  reaches a terminal status — this covers the normal finalize path, the kill
+  route, ghost recovery, and the shutdown fallback. `Running` runs are
+  skipped; a `NULL` `total_cost_usd` is allowed. The upsert is idempotent
+  (last write wins by `run_id`).
+- **Read path for all cost analytics.** `cost_summary_for()` and
+  `daily_buckets_for()` aggregate from `cost_ledger` (not `workflow_runs`),
+  so `/api/cost/workflows` and `/api/cost/workflows/{id}` keep counting the
+  spend of deleted workflows/runs. `list_ledger_workflows()` exposes the
+  distinct `(workflow_id, workflow_name)` pairs (latest name wins) so the
+  cost list endpoint can name deleted workflows.
+- **Backfilled by m008.** Existing terminal `workflow_runs` rows are copied
+  into the ledger when the migration runs (see below).
 
 ### Encoding rules
 
@@ -230,7 +277,7 @@ pub trait WorkflowStore: Send + Sync {
 | `find_by_name` | Looks up a single workflow by name; returns `None` if not found. |
 | `create_workflow` | Validates, assigns a UUIDv7 ID, sets `version: 1`, INSERTs, and returns the new workflow. |
 | `update_workflow` | Partial update; bumps `version` when any definition-affecting field changes. Returns `NotFound` or `Conflict` as appropriate. |
-| `delete_workflow` | DELETEs a workflow by UUID; returns `NotFound` if it does not exist. |
+| `delete_workflow` | Transactional cascade delete (v4.2.14): returns `Conflict` if the workflow has any `Running` run, otherwise deletes the run history and the workflow row in one transaction. Returns `NotFound` if the workflow does not exist. Cost-ledger rows are retained. |
 | `record_run_outcome` | Records a terminal run outcome on the parent workflow (updates `last_run_id`, `last_run_status`, `last_run_at`; bumps `updated_at`; does NOT bump `version`). Returns `Result<()>` (anyhow); note this differs from the `WorkflowRunStore` trait which uses `Result<_, AcsError>`. |
 
 ### SqliteWorkflowStore
@@ -290,6 +337,8 @@ pub trait WorkflowRunStore: Send + Sync {
     ) -> Result<Vec<WorkflowRun>, AcsError>;
     async fn count_runs(&self, workflow_id: Uuid) -> Result<usize, AcsError>;
     async fn delete_run(&self, run_id: Uuid) -> Result<(), AcsError>;
+    async fn purge_runs(&self, workflow_id: Uuid) -> Result<Vec<Uuid>, AcsError>;
+    async fn list_ledger_workflows(&self) -> Result<Vec<(Uuid, String)>, AcsError>;
     async fn list_recent_runs(&self, limit: usize, offset: usize) -> Result<Vec<WorkflowRun>, AcsError>;
     async fn count_all_runs(&self) -> Result<usize, AcsError>;
     async fn cost_summary_for(&self, workflow_id: Uuid, display_tz: &Tz) -> Result<CostSummary, AcsError>;
@@ -304,7 +353,9 @@ pub trait WorkflowRunStore: Send + Sync {
 | `get_run` | Single-row SELECT by primary key; returns `None` if the row is absent. |
 | `list_runs` | `SELECT … WHERE workflow_id = ? ORDER BY run_id DESC LIMIT ? OFFSET ?`. `limit=0` is translated to `-1` (SQLite "no limit"). |
 | `count_runs` | `SELECT COUNT(*) … WHERE workflow_id = ?`. |
-| `delete_run` | `DELETE FROM workflow_runs WHERE run_id = ?` (best-effort; absent rows are not an error). Log files are not removed by `delete_run`. |
+| `delete_run` | `DELETE FROM workflow_runs WHERE run_id = ?` (best-effort; absent rows are not an error). Log files are not removed by `delete_run` (the HTTP handler removes them best-effort). Cost-ledger rows are untouched. |
+| `purge_runs` | Deletes every **non-Running** run for the workflow in one transaction and returns the deleted run ids so the caller can clean up log files. `Running` runs are skipped. Cost-ledger rows are untouched. Backs `DELETE /api/workflows/{id}/runs`. |
+| `list_ledger_workflows` | Distinct `(workflow_id, workflow_name)` pairs present in `cost_ledger`, using the name recorded on each workflow's most recent terminal run. Includes deleted workflows; used by `GET /api/cost/workflows[/{id}]` to name them. |
 | `list_recent_runs` | Cross-workflow recent-runs feed: `SELECT … ORDER BY run_id DESC LIMIT ? OFFSET ?` (no `workflow_id` filter). Backs `GET /api/runs/recent`. |
 | `count_all_runs` | `SELECT COUNT(*) FROM workflow_runs` across all workflows. Pairs with `list_recent_runs` for paginated totals. |
 | `cost_summary_for` | Computes the per-workflow `CostSummary` (30-day + 1-year totals) windowed against `display_tz` calendar-day boundaries. Entry point used by `CostCache`. |
@@ -341,9 +392,9 @@ The `workflow_runs` table has three secondary indexes:
 | `idx_workflow_runs_finished_at` | `(finished_at)` | Cross-workflow recency queries. |
 | `idx_workflow_runs_status` | `(status)` | Filters that pick out e.g. all currently-running rows. |
 
-The cost-analytics aggregation query — `SUM(CASE WHEN finished_at >= ? THEN total_cost_usd END)` plus `COUNT(...)` over two windows — runs once per workflow per `GET /api/cost/workflows[/{id}]` cache miss. The `idx_workflow_runs_workflow_id_finished_at` composite index established in m002 covers this access pattern: the WHERE clause filters by `workflow_id`, `status IN (...)`, and `finished_at >= ?`, with the conditional SUMs evaluated over the filtered rows.
+The cost-analytics aggregation query — `SUM(CASE WHEN finished_at >= ? THEN total_cost_usd END)` plus `COUNT(...)` over two windows — runs once per workflow per `GET /api/cost/workflows[/{id}]` cache miss. Since v4.2.14 it reads from `cost_ledger` (not `workflow_runs`) so deleted history still counts; the `idx_cost_ledger_workflow_id_finished_at` composite index covers this access pattern: the WHERE clause filters by `workflow_id`, `status IN (...)`, and `finished_at >= ?`, with the conditional SUMs evaluated over the filtered rows.
 
-The daily-bucket query fetches `(finished_at, status, total_cost_usd, total_input_tokens, total_output_tokens)` over the window for the requested workflow (or all workflows for the system aggregate). Per-day grouping happens in Rust using `chrono_tz` to convert each UTC `finished_at` to the daemon's `display_timezone` local date — this avoids fighting SQLite's `localtime` / `strftime` for cross-platform consistency. The same `idx_workflow_runs_workflow_id_finished_at` composite index covers both per-workflow and system-wide queries. Both query paths are invoked exclusively by the cost endpoint handlers at `GET /api/cost/workflows[/{id}]`. The `total_input_tokens` / `total_output_tokens` columns were added in v4.2.11 (migration m007).
+The daily-bucket query fetches `(finished_at, status, total_cost_usd, total_input_tokens, total_output_tokens)` from `cost_ledger` over the window for the requested workflow (or all workflows for the system aggregate). Per-day grouping happens in Rust using `chrono_tz` to convert each UTC `finished_at` to the daemon's `display_timezone` local date — this avoids fighting SQLite's `localtime` / `strftime` for cross-platform consistency. The `idx_cost_ledger_workflow_id_finished_at` composite index covers both per-workflow and system-wide queries. Both query paths are invoked exclusively by the cost endpoint handlers at `GET /api/cost/workflows[/{id}]`. The `total_input_tokens` / `total_output_tokens` columns were added in v4.2.11 (migration m007); the switch to `cost_ledger` landed in v4.2.14 (migration m008).
 
 ---
 
@@ -734,6 +785,33 @@ columns to the `workflow_runs` table introduced in v4.2.11. Both columns are
 | `acs.db` does not exist | No-op (return `Ok(false)`) — fresh install |
 | `total_input_tokens` column already present on `workflow_runs` | No-op (return `Ok(false)`) — idempotent |
 | Otherwise | BEGIN transaction → `ALTER TABLE workflow_runs ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0;` and `ALTER TABLE workflow_runs ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0;` → COMMIT |
+
+### m008_cost_ledger_cascade
+
+`m008_cost_ledger_cascade` (v4.2.14, ACS-25) introduces the durable
+`cost_ledger` table and adds `ON DELETE CASCADE` to the
+`workflow_runs.workflow_id` foreign key so `DELETE /api/workflows/{id}` no
+longer fails with `FOREIGN KEY constraint failed` once a workflow has run
+history.
+
+The `cost_ledger` table itself is created by `schema.rs` on every open; the
+migration is responsible for backfilling it and rebuilding `workflow_runs`.
+SQLite cannot alter an existing foreign key, so the CASCADE is installed via
+the standard table rebuild (create new table → copy rows → drop old →
+rename → recreate the three indexes), executed with `PRAGMA foreign_keys =
+OFF` around a single transaction.
+
+| Condition | Action |
+|---|---|
+| `acs.db` does not exist | No-op (return `Ok(false)`) — fresh install (schema.rs ships CASCADE + `cost_ledger` from the start) |
+| `workflow_runs.workflow_id` FK already `ON DELETE CASCADE` | No-op (return `Ok(false)`) — idempotent |
+| Otherwise | `PRAGMA foreign_keys = OFF` → BEGIN transaction → `INSERT OR IGNORE INTO cost_ledger … SELECT … FROM workflow_runs WHERE status IN ('Completed','Failed','Killed')` (workflow_name extracted from the stored `workflow_snapshot` JSON) → rebuild `workflow_runs` with CASCADE → COMMIT → `PRAGMA foreign_keys = ON` |
+
+Note that although the FK now cascades, `SqliteWorkflowStore::delete_workflow`
+also deletes the run rows explicitly inside its own transaction (after
+refusing with `Conflict` when any run is `Running`) — the CASCADE clause is
+defense in depth. Workflow deletion additionally removes the workflow's log
+directory `{data_dir}/logs/{workflow_id}/` best-effort from the HTTP handler.
 
 ---
 

--- a/docs/workflow-management.md
+++ b/docs/workflow-management.md
@@ -666,6 +666,29 @@ Each step's output is wrapped in marker lines:
 
 The daemon version is embedded in markers (`ACS-<VERSION>`) to allow log parsers to handle format evolution.
 
+### Deleting workflows and runs (v4.2.14)
+
+Deletion semantics changed in v4.2.14 (ACS-25):
+
+- **`DELETE /api/workflows/{id}`** deletes the workflow **and its entire run
+  history** in one transaction, then removes the workflow's log directory
+  `<data_dir>/logs/<workflow_id>/` best-effort. If the workflow has any
+  `Running` run the request is refused with `409 Conflict` — kill the run(s)
+  via `POST /api/runs/{run_id}/kill` or wait for them to finish. (Before
+  v4.2.14 this endpoint returned a 500 `FOREIGN KEY constraint failed` for
+  any workflow that had ever run.)
+- **`DELETE /api/runs/{run_id}`** deletes a single run record and its log
+  file. Refused with `409 Conflict` while the run is `Running`.
+- **`DELETE /api/workflows/{id}/runs`** bulk-purges all **non-Running** runs
+  for a workflow (rows + log files) and returns `{"deleted": <count>}`.
+  `Running` runs are skipped; the workflow definition is untouched.
+
+In all three cases the run's cost/token bookkeeping is **retained**: terminal
+runs are mirrored into the durable `cost_ledger` table (no foreign keys) at
+finalization, and the cost analytics endpoints aggregate from that ledger, so
+deleted workflows and runs keep counting toward historical spend. See
+[`storage.md`](./storage.md) and [`api-reference.md`](./api-reference.md).
+
 ---
 
 ## Cron Expressions

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acs-electron",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acs-electron",
-      "version": "4.2.13",
+      "version": "4.2.14",
       "workspaces": [
         "packages/*"
       ],
@@ -16270,7 +16270,7 @@
     },
     "packages/app": {
       "name": "@acs/app",
-      "version": "4.2.13",
+      "version": "4.2.14",
       "devDependencies": {
         "electron": "33.4.11",
         "electron-builder": "^26.0.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-electron",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "private": true,
   "//workspaces": "desktopapp is excluded so it installs standalone (own node_modules + package-lock.json) and `npm install` / `npm run dev` work from inside its folder. It also has outputFileTracingRoot pinned in its next.config.ts so Next doesn't walk up to this lockfile.",
   "workspaces": [

--- a/electron/packages/app/package.json
+++ b/electron/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acs/app",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "private": true,
   "description": "Agent Cron Scheduler desktop application",
   "author": "Jtonna",


### PR DESCRIPTION
## Summary

Fixes `DELETE /api/workflows/{id}` returning `500 {"error":"internal_error","message":"Storage error: FOREIGN KEY constraint failed"}` for any workflow with run history, and hardens deletion semantics around it.

Ticket: https://linear.app/jtonna/issue/ACS-25/delete-apiworkflowsid-returns-500-fk-constraint-once-run-history

### Durable cost ledger (cost survives deletion)
- New `cost_ledger` table (migration **m008_cost_ledger_cascade**, shipped as **v4.2.14**): append-only skinny rows (`run_id` PK, `workflow_id`, `workflow_name`, `started_at`, `finished_at`, `status`, `total_cost_usd`, `total_input_tokens`, `total_output_tokens`) with **no foreign keys**.
- Ledger row is upserted whenever a run is persisted with a terminal status (covers finalize, kill route, ghost recovery, shutdown fallback). Null cost allowed; `Running` skipped.
- m008 backfills the ledger from all existing terminal `workflow_runs` rows (name extracted from the stored workflow snapshot) and is idempotent.
- `cost_summary_for` / `daily_buckets_for` now aggregate from `cost_ledger`, so `/api/cost/workflows[/{id}]` keeps counting deleted workflows/runs. Deleted workflows appear in the cost list (and stay queryable per-id) using the ledger's stored name. Response shapes unchanged.

### Cascade workflow delete
- `delete_workflow()` is now transactional: 409 `Conflict` while any run is `Running`, otherwise deletes `workflow_runs` + the workflow row atomically.
- m008 also rebuilds `workflow_runs` with `ON DELETE CASCADE` on the FK (standard SQLite table rebuild; indexes preserved) as defense in depth; fresh installs get it via `schema.rs`.
- After commit, the handler best-effort removes `<data_dir>/logs/<workflow_id>/` (warning on failure).

### Run purge endpoints
- `DELETE /api/runs/{run_id}`: 404 unknown, 409 while `Running`, 204 on success + best-effort log-file removal. Ledger untouched.
- `DELETE /api/workflows/{id}/runs`: bulk-purges all non-`Running` runs (rows + log files best-effort), returns `200 {"deleted": n}`; `Running` runs skipped, workflow untouched.

### Error mapping
- `map_store_error()` gains a `Storage` arm: constraint/FK messages map to 409 `conflict` (fallback string match); primary paths return `AcsError::Conflict` from the storage layer.

### Docs / spec / version
- `docs/api-reference.md`, `docs/storage.md`, `docs/workflow-management.md`, `acs/web/openapi.yaml` updated (new endpoints, 409s, cost_ledger, m008).
- Version bumped 4.2.13 → 4.2.14 everywhere previous migration releases bumped it (Cargo.toml/lock, openapi, electron package manifests).

### Also included
- `test_executor_agent_step_dispatched` marked `#[ignore]` (separate commit): it spawns a real `claude -p ... --dangerously-skip-permissions` session when the CLI is on PATH. Pre-existing local change picked up in this worktree; kept for visibility.

## Test evidence

All quality gates pass on the branch (Windows, `acs/`):

- `cargo test`: **583 passed / 0 failed / 1 ignored** (lib) + **9 passed** (cli_tests) + **79 passed** (workflow_api_tests, includes 6 new ACS-25 D-tests) + 0 doc-tests
- `cargo clippy -- -D warnings`: clean (exit 0)
- `cargo fmt -- --check`: clean (exit 0)

New coverage: cascade delete with history (the exact former-500 repro), running-run 409 guards (workflow + run), single-run delete lifecycle (204 → 404, log file removed), bulk purge count/skip semantics, ledger writes at finalization, ledger survival across run/workflow deletion, deleted-workflow costs on both cost endpoints, m008 backfill + idempotency + CASCADE verification.

## Manual verification note

Post-deploy, workflow **nasa-apod-test** (`019f205a-6cd2-78d2-bbe6-c6dca6feefdc`) on the review daemon (port 8377) can be used to verify: `DELETE /api/workflows/019f205a-6cd2-78d2-bbe6-c6dca6feefdc` should return 204 (previously 500), its runs should be gone, and its historical cost should still appear in `GET /api/cost/workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)