### PR TITLE
ACS-25: soft-delete workflows, preserve run/cost history

### DIFF
--- a/acs/Cargo.lock
+++ b/acs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-cron-scheduler"
-version = "4.2.13"
+version = "4.2.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/acs/Cargo.toml
+++ b/acs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-cron-scheduler"
-version = "4.2.13"
+version = "4.2.14"
 edition = "2021"
 license = "MIT"
 

--- a/acs/src/daemon/mod.rs
+++ b/acs/src/daemon/mod.rs
@@ -643,24 +643,28 @@ pub async fn start_daemon(
         }
     }
 
-    // Run pending migrations (numbered migration system).
-    // Must run AFTER tracing init so migration logs are visible.
+    // Run pending migrations (numbered migration system, tracked in the
+    // schema_migrations table). Must run AFTER tracing init so migration
+    // logs are visible.
     match crate::migration::run_pending(&data_dir).await {
         Ok(report) => {
-            if !report.newly_applied.is_empty() {
-                tracing::info!("Migrations applied: {:?}", report.newly_applied);
-            }
-            if !report.already_applied.is_empty() {
-                tracing::debug!(
-                    "Migrations already applied (skipped): {:?}",
-                    report.already_applied
+            if !report.seeded.is_empty() {
+                tracing::info!(
+                    "Migration tracking backfilled from legacy migrations.json: {:?}",
+                    report.seeded
                 );
             }
-            if !report.skipped_not_needed.is_empty() {
+            if !report.ran.is_empty() {
+                tracing::info!("Migrations applied: {:?}", report.ran);
+            }
+            if !report.ran_no_op.is_empty() {
                 tracing::debug!(
-                    "Migrations not needed (skipped): {:?}",
-                    report.skipped_not_needed
+                    "Migrations processed with nothing to do: {:?}",
+                    report.ran_no_op
                 );
+            }
+            if !report.skipped.is_empty() {
+                tracing::debug!("Migrations already applied (skipped): {:?}", report.skipped);
             }
         }
         Err(e) => {

--- a/acs/src/daemon/scheduler.rs
+++ b/acs/src/daemon/scheduler.rs
@@ -550,6 +550,7 @@ mod tests {
             schedule_mode,
             enabled: true,
             is_favorited: false,
+            deleted: false,
             steps: vec![StepDef::Shell(ShellStep {
                 common: StepDefCommon {
                     id: "s1".to_string(),

--- a/acs/src/migration/legacy_types.rs
+++ b/acs/src/migration/legacy_types.rs
@@ -3,6 +3,11 @@
 //! These structs describe the on-disk shape of `jobs.json` from the pre-Phase 6
 //! era. They are kept here so the migration code can deserialize old files.
 //! Nothing outside of the `migration` module should reference these types.
+//!
+//! Everything in this module is an intentionally frozen snapshot of a legacy
+//! on-disk format. It is deliberately decoupled from the live model types: do
+//! NOT update it when live models change — a frozen migration input must stay
+//! exactly as it was when the format shipped.
 
 use std::collections::HashMap;
 
@@ -10,7 +15,14 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::models::workflow::ScheduleMode;
+/// Frozen copy of the schedule-mode values understood by the legacy
+/// `jobs.json` format (and re-emitted verbatim into `workflows.json`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub enum ScheduleMode {
+    #[default]
+    Cron,
+    WaitForCompletion,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "value")]

--- a/acs/src/migration/m001_jobs_to_workflows.rs
+++ b/acs/src/migration/m001_jobs_to_workflows.rs
@@ -37,9 +37,117 @@ use uuid::Uuid;
 use crate::errors::AcsError;
 use crate::migration::legacy_types::{ExecutionType, Job};
 use crate::migration::Migration;
-use crate::models::workflow::{
-    CaptureSpec, FailurePolicy, RunStatus, ScriptStep, ShellStep, StepDef, StepDefCommon, Workflow,
+
+use frozen::{
+    CaptureSpec, FailurePolicy, RunStatus, ScriptStep, ShellStep, Step as StepDef,
+    StepCommon as StepDefCommon, Workflow,
 };
+
+/// Frozen snapshot of the workflow JSON shape this migration has always
+/// produced. Intentionally decoupled from the live model types: do NOT update
+/// this module when live models change — a frozen migration's output must
+/// stay exactly as it was when the migration shipped. Later migrations and
+/// the runtime read this output with lenient, default-filling parsers, so
+/// fields added to the live model after this migration are simply absent
+/// here and take their defaults downstream.
+mod frozen {
+    use std::collections::HashMap;
+
+    use chrono::{DateTime, Utc};
+    use serde::Serialize;
+    use uuid::Uuid;
+
+    use crate::migration::legacy_types::ScheduleMode;
+
+    /// Only the `abort` policy is ever emitted by this migration.
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub(super) enum FailurePolicy {
+        Abort,
+    }
+
+    /// Only terminal statuses derived from a legacy exit code are emitted.
+    #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+    pub(super) enum RunStatus {
+        Completed,
+        Failed,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    pub(super) struct CaptureSpec {
+        pub stdout_max_bytes: usize,
+        pub parser: Option<String>,
+    }
+
+    impl Default for CaptureSpec {
+        fn default() -> Self {
+            CaptureSpec {
+                stdout_max_bytes: 65536,
+                parser: None,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    pub(super) struct StepCommon {
+        pub id: String,
+        pub on_failure: Option<FailurePolicy>,
+        pub always_run: bool,
+        pub timeout_secs: Option<u64>,
+        pub working_dir: Option<String>,
+        pub env_vars: Option<HashMap<String, String>>,
+        pub capture: CaptureSpec,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    #[serde(tag = "kind", rename_all = "snake_case")]
+    pub(super) enum Step {
+        Shell(ShellStep),
+        Script(ScriptStep),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    pub(super) struct ShellStep {
+        #[serde(flatten)]
+        pub common: StepCommon,
+        pub command: String,
+        pub pass_stdin: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    pub(super) struct ScriptStep {
+        #[serde(flatten)]
+        pub common: StepCommon,
+        pub path: String,
+        pub script_type: Option<String>,
+        pub args: Option<String>,
+        pub pass_stdin: bool,
+    }
+
+    /// The workflow record shape written to `workflows.json`.
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    pub(super) struct Workflow {
+        pub id: Uuid,
+        pub name: String,
+        pub version: u32,
+        pub schedule: String,
+        pub timezone: Option<String>,
+        pub schedule_mode: ScheduleMode,
+        pub enabled: bool,
+        pub steps: Vec<Step>,
+        pub default_input: Option<serde_json::Value>,
+        pub working_dir: Option<String>,
+        pub env_vars: Option<HashMap<String, String>>,
+        pub allow_concurrent: bool,
+        pub on_failure: FailurePolicy,
+        pub last_run_at: Option<DateTime<Utc>>,
+        pub last_run_status: Option<RunStatus>,
+        pub last_run_id: Option<Uuid>,
+        pub next_run_at: Option<DateTime<Utc>>,
+        pub created_at: DateTime<Utc>,
+        pub updated_at: DateTime<Utc>,
+    }
+}
 
 // ── Migration impl ────────────────────────────────────────────────────────────
 
@@ -396,8 +504,6 @@ fn build_workflow(job: Job, steps: Vec<StepDef>) -> Workflow {
         timezone: job.timezone,
         schedule_mode: job.schedule_mode,
         enabled: job.enabled,
-        is_favorited: false,
-        deleted: false,
         steps,
         default_input: None,
         working_dir: job.working_dir,
@@ -435,8 +541,7 @@ fn script_type_from_path(path: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::migration::legacy_types::ExecutionType;
-    use crate::models::workflow::{RunStatus, ScheduleMode, StepDef};
+    use crate::migration::legacy_types::{ExecutionType, ScheduleMode};
     use chrono::Utc;
     use tempfile::TempDir;
     use uuid::Uuid;
@@ -560,7 +665,6 @@ mod tests {
             let common = match step {
                 StepDef::Shell(s) => &s.common,
                 StepDef::Script(s) => &s.common,
-                _ => panic!("Unexpected step kind"),
             };
             assert_eq!(
                 common.timeout_secs,
@@ -706,14 +810,20 @@ mod tests {
             "workflows.json should exist after migration"
         );
 
+        // Parse with the LIVE model deliberately: this cross-checks that the
+        // frozen output shape stays readable by the runtime's own parser
+        // (fields added to the live model after this migration fill in via
+        // serde defaults).
         let content = tokio::fs::read_to_string(&wf_path).await.unwrap();
-        let workflows: Vec<Workflow> = serde_json::from_str(&content).unwrap();
+        let workflows: Vec<crate::models::workflow::Workflow> =
+            serde_json::from_str(&content).unwrap();
         assert_eq!(workflows.len(), 1);
         assert_eq!(
             workflows[0].id, job.id,
             "workflow id must match original job id"
         );
         assert_eq!(workflows[0].name, job.name);
+        assert!(!workflows[0].deleted, "absent field takes its default");
     }
 
     #[tokio::test]

--- a/acs/src/migration/m001_jobs_to_workflows.rs
+++ b/acs/src/migration/m001_jobs_to_workflows.rs
@@ -397,6 +397,7 @@ fn build_workflow(job: Job, steps: Vec<StepDef>) -> Workflow {
         schedule_mode: job.schedule_mode,
         enabled: job.enabled,
         is_favorited: false,
+        deleted: false,
         steps,
         default_input: None,
         working_dir: job.working_dir,

--- a/acs/src/migration/m002_json_to_sqlite.rs
+++ b/acs/src/migration/m002_json_to_sqlite.rs
@@ -30,15 +30,15 @@
 //! is returned; `migration::run_pending` propagates it, which aborts daemon
 //! startup with a non-zero exit code.
 //!
-//! # `migrations.json` is intentionally left in place
+//! # `migrations.json` is not this migration's concern
 //!
 //! Migration execution is tracked in the `schema_migrations` table inside
 //! `acs.db` (owned by the migration runner, see `migration::mod`).
 //! `migrations.json` is the legacy tracking file: the runner reads it one
-//! time to backfill the tracking table on databases that predate it, and
-//! never writes it again. This migration leaves the file untouched. The
-//! `meta` table exists in the schema for future SQLite-only metadata but is
-//! unused by this migration.
+//! time to backfill the tracking table on databases that predate it, then
+//! deletes it. This migration leaves the file untouched. The `meta` table
+//! exists in the schema for future SQLite-only metadata but is unused by
+//! this migration.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -49,8 +49,88 @@ use uuid::Uuid;
 
 use crate::errors::AcsError;
 use crate::migration::Migration;
-use crate::models::workflow::{Workflow, WorkflowRun};
 use crate::storage::sqlite;
+
+use frozen::{RunRecord, WorkflowRecord};
+
+/// Frozen snapshot of the legacy JSON shapes this migration converts.
+/// Intentionally decoupled from the live model types: do NOT update this
+/// module when live models change — a frozen migration must keep reading and
+/// writing exactly the shapes it shipped with. Structured fields exist only
+/// where the conversion needs a typed value (ids, timestamps, SQL columns);
+/// everything else is carried as opaque JSON and written through verbatim.
+mod frozen {
+    use chrono::{DateTime, Utc};
+    use serde::Deserialize;
+    use serde_json::Value;
+    use uuid::Uuid;
+
+    fn default_schedule_mode() -> String {
+        "Cron".to_string()
+    }
+
+    fn default_on_failure() -> Value {
+        Value::String("abort".to_string())
+    }
+
+    fn default_true() -> bool {
+        true
+    }
+
+    /// One entry of `workflows.json`, at the shape this migration converts.
+    #[derive(Debug, Clone, Deserialize)]
+    pub(super) struct WorkflowRecord {
+        pub id: Uuid,
+        pub name: String,
+        pub version: u32,
+        pub schedule: String,
+        #[serde(default)]
+        pub timezone: Option<String>,
+        #[serde(default = "default_schedule_mode")]
+        pub schedule_mode: String,
+        pub enabled: bool,
+        pub steps: Value,
+        #[serde(default)]
+        pub default_input: Option<Value>,
+        #[serde(default)]
+        pub working_dir: Option<String>,
+        #[serde(default)]
+        pub env_vars: Option<Value>,
+        #[serde(default = "default_true")]
+        pub allow_concurrent: bool,
+        #[serde(default = "default_on_failure")]
+        pub on_failure: Value,
+        #[serde(default)]
+        pub last_run_at: Option<DateTime<Utc>>,
+        #[serde(default)]
+        pub last_run_status: Option<String>,
+        #[serde(default)]
+        pub last_run_id: Option<Uuid>,
+        pub created_at: DateTime<Utc>,
+        pub updated_at: DateTime<Utc>,
+    }
+
+    /// One `runs/<workflow_id>/<run_id>.json` file, at the shape this
+    /// migration converts.
+    #[derive(Debug, Clone, Deserialize)]
+    pub(super) struct RunRecord {
+        pub run_id: Uuid,
+        pub workflow_id: Uuid,
+        pub workflow_version: u32,
+        pub workflow_snapshot: Value,
+        pub started_at: DateTime<Utc>,
+        #[serde(default)]
+        pub finished_at: Option<DateTime<Utc>>,
+        pub status: String,
+        #[serde(default)]
+        pub trigger_input: Option<Value>,
+        pub steps: Value,
+        #[serde(default)]
+        pub total_cost_usd: Option<f64>,
+        #[serde(default)]
+        pub total_duration_ms: Option<u64>,
+    }
+}
 
 // ─── Migration impl ───────────────────────────────────────────────────────────
 
@@ -117,7 +197,7 @@ impl Migration for JsonToSqlite {
         // run files for some out-of-band reason.
         let valid_workflow_ids: HashSet<Uuid> = workflows.iter().map(|w| w.id).collect();
         let total_run_files = all_runs.len();
-        let mut runs: Vec<WorkflowRun> = Vec::with_capacity(total_run_files);
+        let mut runs: Vec<RunRecord> = Vec::with_capacity(total_run_files);
         let mut orphan_count: usize = 0;
         for run in all_runs {
             if valid_workflow_ids.contains(&run.workflow_id) {
@@ -217,21 +297,21 @@ fn workflows_table_exists(path: &Path) -> Result<bool, AcsError> {
 
 // ─── JSON readers ─────────────────────────────────────────────────────────────
 
-async fn read_workflows_json(path: &Path) -> Result<Vec<Workflow>, AcsError> {
+async fn read_workflows_json(path: &Path) -> Result<Vec<WorkflowRecord>, AcsError> {
     if !path.exists() {
         return Ok(Vec::new());
     }
     let content = tokio::fs::read_to_string(path)
         .await
         .map_err(|e| AcsError::Storage(format!("Failed to read {}: {}", path.display(), e)))?;
-    serde_json::from_str::<Vec<Workflow>>(&content)
+    serde_json::from_str::<Vec<WorkflowRecord>>(&content)
         .map_err(|e| AcsError::Storage(format!("Failed to parse {}: {}", path.display(), e)))
 }
 
 /// Walk `<runs_dir>/<workflow_uuid>/<run_uuid>.json` and parse every run file.
 /// Files at the top level (notably `index.json`) are skipped — the index is
 /// derived metadata, not a primary source.
-async fn read_run_files(runs_dir: &Path) -> Result<Vec<WorkflowRun>, AcsError> {
+async fn read_run_files(runs_dir: &Path) -> Result<Vec<RunRecord>, AcsError> {
     if !runs_dir.exists() {
         return Ok(Vec::new());
     }
@@ -286,7 +366,7 @@ async fn read_run_files(runs_dir: &Path) -> Result<Vec<WorkflowRun>, AcsError> {
             let content = tokio::fs::read_to_string(&run_path).await.map_err(|e| {
                 AcsError::Storage(format!("Failed to read {}: {}", run_path.display(), e))
             })?;
-            let run: WorkflowRun = serde_json::from_str(&content).map_err(|e| {
+            let run: RunRecord = serde_json::from_str(&content).map_err(|e| {
                 AcsError::Storage(format!("Failed to parse {}: {}", run_path.display(), e))
             })?;
             runs.push(run);
@@ -303,8 +383,8 @@ async fn read_run_files(runs_dir: &Path) -> Result<Vec<WorkflowRun>, AcsError> {
 /// transaction, verifies, and commits.
 fn migrate_blocking(
     db_path: &Path,
-    workflows: Vec<Workflow>,
-    runs: Vec<WorkflowRun>,
+    workflows: Vec<WorkflowRecord>,
+    runs: Vec<RunRecord>,
 ) -> Result<(), AcsError> {
     let mut conn = sqlite::open_with_schema(db_path)?;
 
@@ -371,54 +451,14 @@ fn migrate_blocking(
     Ok(())
 }
 
-/// Insert a single workflow row. Mirrors the column layout the
-/// `SqliteWorkflowStore` writes so the runtime can read these rows back
-/// unchanged after the migration.
-fn insert_workflow(conn: &Connection, wf: &Workflow) -> Result<(), AcsError> {
-    let steps_json =
-        serde_json::to_string(&wf.steps).map_err(|e| AcsError::Storage(e.to_string()))?;
-    let default_input = wf
-        .default_input
-        .as_ref()
-        .map(serde_json::to_string)
-        .transpose()
-        .map_err(|e| AcsError::Storage(e.to_string()))?;
-    let env_vars = wf
-        .env_vars
-        .as_ref()
-        .map(serde_json::to_string)
-        .transpose()
-        .map_err(|e| AcsError::Storage(e.to_string()))?;
-
-    let schedule_mode = match serde_json::to_value(&wf.schedule_mode)
-        .map_err(|e| AcsError::Storage(e.to_string()))?
-    {
-        serde_json::Value::String(s) => s,
-        other => {
-            return Err(AcsError::Storage(format!(
-                "ScheduleMode did not serialize to a string: {}",
-                other
-            )));
-        }
-    };
-
-    let on_failure =
-        serde_json::to_string(&wf.on_failure).map_err(|e| AcsError::Storage(e.to_string()))?;
-
-    let last_run_status = match wf.last_run_status {
-        None => None,
-        Some(ref s) => {
-            match serde_json::to_value(s).map_err(|e| AcsError::Storage(e.to_string()))? {
-                serde_json::Value::String(s) => Some(s),
-                other => {
-                    return Err(AcsError::Storage(format!(
-                        "RunStatus did not serialize to a string: {}",
-                        other
-                    )));
-                }
-            }
-        }
-    };
+/// Insert a single workflow row. Lists exactly the columns that existed at
+/// this migration's schema level; columns added by later migrations (for
+/// example `is_favorited` and `deleted`) are filled by their SQL `DEFAULT`
+/// clauses. JSON-shaped values are written through verbatim from the frozen
+/// record.
+fn insert_workflow(conn: &Connection, wf: &WorkflowRecord) -> Result<(), AcsError> {
+    let default_input = wf.default_input.as_ref().map(|v| v.to_string());
+    let env_vars = wf.env_vars.as_ref().map(|v| v.to_string());
 
     conn.execute(
         "INSERT INTO workflows (
@@ -438,16 +478,16 @@ fn insert_workflow(conn: &Connection, wf: &Workflow) -> Result<(), AcsError> {
             wf.version as i64,
             wf.schedule,
             wf.timezone,
-            schedule_mode,
+            wf.schedule_mode,
             wf.enabled as i64,
-            steps_json,
+            wf.steps.to_string(),
             default_input,
             wf.working_dir,
             env_vars,
             wf.allow_concurrent as i64,
-            on_failure,
+            wf.on_failure.to_string(),
             wf.last_run_at.map(|d| d.to_rfc3339()),
-            last_run_status,
+            wf.last_run_status,
             wf.last_run_id.map(|u| u.to_string()),
             wf.created_at.to_rfc3339(),
             wf.updated_at.to_rfc3339(),
@@ -463,29 +503,11 @@ fn insert_workflow(conn: &Connection, wf: &Workflow) -> Result<(), AcsError> {
     Ok(())
 }
 
-/// Insert a single workflow_run row.
-fn insert_run(conn: &Connection, run: &WorkflowRun) -> Result<(), AcsError> {
-    let snapshot_json = serde_json::to_string(&run.workflow_snapshot)
-        .map_err(|e| AcsError::Storage(e.to_string()))?;
-    let steps_json =
-        serde_json::to_string(&run.steps).map_err(|e| AcsError::Storage(e.to_string()))?;
-    let trigger_input = run
-        .trigger_input
-        .as_ref()
-        .map(serde_json::to_string)
-        .transpose()
-        .map_err(|e| AcsError::Storage(e.to_string()))?;
-
-    let status =
-        match serde_json::to_value(run.status).map_err(|e| AcsError::Storage(e.to_string()))? {
-            serde_json::Value::String(s) => s,
-            other => {
-                return Err(AcsError::Storage(format!(
-                    "RunStatus did not serialize to a string: {}",
-                    other
-                )));
-            }
-        };
+/// Insert a single workflow_run row. Same frozen-columns principle as
+/// [`insert_workflow`]: token-count columns added later are filled by their
+/// SQL `DEFAULT` clauses.
+fn insert_run(conn: &Connection, run: &RunRecord) -> Result<(), AcsError> {
+    let trigger_input = run.trigger_input.as_ref().map(|v| v.to_string());
 
     conn.execute(
         "INSERT INTO workflow_runs (
@@ -497,12 +519,12 @@ fn insert_run(conn: &Connection, run: &WorkflowRun) -> Result<(), AcsError> {
             run.run_id.to_string(),
             run.workflow_id.to_string(),
             run.workflow_version as i64,
-            snapshot_json,
+            run.workflow_snapshot.to_string(),
             run.started_at.to_rfc3339(),
             run.finished_at.map(|d| d.to_rfc3339()),
-            status,
+            run.status,
             trigger_input,
-            steps_json,
+            run.steps.to_string(),
             run.total_cost_usd,
             run.total_duration_ms.map(|n| n as i64),
         ],
@@ -517,14 +539,13 @@ fn insert_run(conn: &Connection, run: &WorkflowRun) -> Result<(), AcsError> {
     Ok(())
 }
 
-/// Re-read the just-inserted workflow row as JSON-shaped fields, deserialise
-/// it back into a `Workflow`, and confirm structural equality with the
-/// source. Verifies the round-trip without coupling to the runtime row
-/// mapper (which is private to the SQLite store module).
-fn verify_workflow_round_trip(conn: &Connection, source: &Workflow) -> Result<(), AcsError> {
+/// Re-read the just-inserted workflow row and confirm the JSON-shaped columns
+/// parse back to values structurally equal to the frozen source. Verifies the
+/// round-trip without coupling to any live model or the runtime row mapper.
+fn verify_workflow_round_trip(conn: &Connection, source: &WorkflowRecord) -> Result<(), AcsError> {
     let id_s = source.id.to_string();
 
-    let (steps_json, on_failure_json, snapshot_name): (String, String, String) = conn
+    let (steps_json, on_failure_json, stored_name): (String, String, String) = conn
         .query_row(
             "SELECT steps_json, on_failure, name FROM workflows WHERE id = ?1",
             [&id_s],
@@ -537,14 +558,14 @@ fn verify_workflow_round_trip(conn: &Connection, source: &Workflow) -> Result<()
             ))
         })?;
 
-    if snapshot_name != source.name {
+    if stored_name != source.name {
         return Err(AcsError::Storage(format!(
             "Workflow {} verification mismatch: name {:?} != {:?}",
-            source.id, snapshot_name, source.name
+            source.id, stored_name, source.name
         )));
     }
 
-    let round_tripped_steps: Vec<crate::models::workflow::StepDef> =
+    let round_tripped_steps: serde_json::Value =
         serde_json::from_str(&steps_json).map_err(|e| {
             AcsError::Storage(format!(
                 "Verification: round-trip parse of steps for {} failed: {}",
@@ -558,7 +579,7 @@ fn verify_workflow_round_trip(conn: &Connection, source: &Workflow) -> Result<()
         )));
     }
 
-    let round_tripped_failure: crate::models::workflow::FailurePolicy =
+    let round_tripped_failure: serde_json::Value =
         serde_json::from_str(&on_failure_json).map_err(|e| {
             AcsError::Storage(format!(
                 "Verification: round-trip parse of on_failure for {} failed: {}",
@@ -575,10 +596,10 @@ fn verify_workflow_round_trip(conn: &Connection, source: &Workflow) -> Result<()
     Ok(())
 }
 
-/// Re-read the just-inserted workflow_run row, deserialise the `steps_json`
-/// blob, and confirm it matches the source. Lightweight smoke check that the
-/// transaction wrote what we expected.
-fn verify_run_round_trip(conn: &Connection, source: &WorkflowRun) -> Result<(), AcsError> {
+/// Re-read the just-inserted workflow_run row and confirm the status and the
+/// `steps_json` blob match the frozen source. Lightweight smoke check that
+/// the transaction wrote what we expected.
+fn verify_run_round_trip(conn: &Connection, source: &RunRecord) -> Result<(), AcsError> {
     let id_s = source.run_id.to_string();
     let (status_s, steps_json): (String, String) = conn
         .query_row(
@@ -593,24 +614,14 @@ fn verify_run_round_trip(conn: &Connection, source: &WorkflowRun) -> Result<(), 
             ))
         })?;
 
-    let expected_status =
-        match serde_json::to_value(source.status).map_err(|e| AcsError::Storage(e.to_string()))? {
-            serde_json::Value::String(s) => s,
-            other => {
-                return Err(AcsError::Storage(format!(
-                    "RunStatus did not serialize to a string: {}",
-                    other
-                )));
-            }
-        };
-    if status_s != expected_status {
+    if status_s != source.status {
         return Err(AcsError::Storage(format!(
             "Run {} verification mismatch: status {:?} != {:?}",
-            source.run_id, status_s, expected_status
+            source.run_id, status_s, source.status
         )));
     }
 
-    let round_tripped_steps: Vec<crate::models::workflow::StepRun> =
+    let round_tripped_steps: serde_json::Value =
         serde_json::from_str(&steps_json).map_err(|e| {
             AcsError::Storage(format!(
                 "Verification: round-trip parse of steps for run {} failed: {}",
@@ -633,11 +644,10 @@ fn verify_run_round_trip(conn: &Connection, source: &WorkflowRun) -> Result<(), 
 mod tests {
     use super::*;
     use crate::models::workflow::{
-        CaptureSpec, FailurePolicy, NewWorkflow, RunStatus, ScheduleMode, ShellStep, StepDef,
-        StepDefCommon, Workflow, WorkflowRun,
+        CaptureSpec, FailurePolicy, NewWorkflow, ScheduleMode, ShellStep, StepDef, StepDefCommon,
+        Workflow, WorkflowRun,
     };
     use chrono::Utc;
-    use std::collections::HashMap;
     use tempfile::TempDir;
 
     fn make_shell_step(id: &str) -> StepDef {
@@ -656,51 +666,44 @@ mod tests {
         })
     }
 
+    /// Build a live [`Workflow`] fixture from a frozen JSON literal at the
+    /// legacy shape this migration converts. Going through `from_value` (not
+    /// a struct literal) keeps this helper immune to live-model field
+    /// additions: new fields simply fill in via their serde defaults.
     fn make_workflow(name: &str) -> Workflow {
         let now = Utc::now();
-        let mut env = HashMap::new();
-        env.insert("FOO".to_string(), "bar".to_string());
-        Workflow {
-            id: Uuid::now_v7(),
-            name: name.to_string(),
-            version: 1,
-            schedule: "*/5 * * * *".to_string(),
-            timezone: Some("America/New_York".to_string()),
-            schedule_mode: ScheduleMode::default(),
-            enabled: true,
-            is_favorited: false,
-            deleted: false,
-            steps: vec![make_shell_step("step-1")],
-            default_input: Some(serde_json::json!({"k": 1})),
-            working_dir: Some("/tmp".to_string()),
-            env_vars: Some(env),
-            allow_concurrent: true,
-            on_failure: FailurePolicy::default(),
-            last_run_at: None,
-            last_run_status: None,
-            last_run_id: None,
-            next_run_at: None,
-            created_at: now,
-            updated_at: now,
-        }
+        serde_json::from_value(serde_json::json!({
+            "id": Uuid::now_v7(),
+            "name": name,
+            "version": 1,
+            "schedule": "*/5 * * * *",
+            "timezone": "America/New_York",
+            "schedule_mode": "Cron",
+            "enabled": true,
+            "steps": [serde_json::to_value(make_shell_step("step-1")).unwrap()],
+            "default_input": {"k": 1},
+            "working_dir": "/tmp",
+            "env_vars": {"FOO": "bar"},
+            "allow_concurrent": true,
+            "on_failure": "abort",
+            "created_at": now,
+            "updated_at": now,
+        }))
+        .expect("fixture must parse into the live model")
     }
 
+    /// Same `from_value` principle as [`make_workflow`], for run fixtures.
     fn make_run(parent: &Workflow) -> WorkflowRun {
-        WorkflowRun {
-            run_id: Uuid::now_v7(),
-            workflow_id: parent.id,
-            workflow_version: parent.version,
-            workflow_snapshot: parent.clone(),
-            started_at: Utc::now(),
-            finished_at: None,
-            status: RunStatus::Running,
-            trigger_input: None,
-            steps: vec![],
-            total_cost_usd: None,
-            total_duration_ms: None,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-        }
+        serde_json::from_value(serde_json::json!({
+            "run_id": Uuid::now_v7(),
+            "workflow_id": parent.id,
+            "workflow_version": parent.version,
+            "workflow_snapshot": parent,
+            "started_at": Utc::now(),
+            "status": "Running",
+            "steps": [],
+        }))
+        .expect("fixture must parse into the live model")
     }
 
     async fn write_workflows_json(dir: &Path, workflows: &[Workflow]) {

--- a/acs/src/migration/m002_json_to_sqlite.rs
+++ b/acs/src/migration/m002_json_to_sqlite.rs
@@ -3,8 +3,12 @@
 //!
 //! # Decision table
 //!
-//! 1. If `<data_dir>/acs.db` already exists → migration is already applied
-//!    (no-op, returns `Ok(false)`).
+//! 1. If `<data_dir>/acs.db` contains a `workflows` table → the conversion
+//!    (or the fresh-install schema) is already in place (no-op, returns
+//!    `Ok(false)`). The check is table-based rather than file-based because
+//!    the migration runner creates `acs.db` up front to host its
+//!    `schema_migrations` tracking table, so file existence alone proves
+//!    nothing.
 //! 2. If neither `<data_dir>/workflows.json` nor `<data_dir>/runs/` exists →
 //!    fresh install. Create `acs.db` with the empty schema and return
 //!    `Ok(true)` so the migration is recorded as applied.
@@ -28,13 +32,13 @@
 //!
 //! # `migrations.json` is intentionally left in place
 //!
-//! ACS-22 §4 step 5 envisaged copying applied-migration state into the
-//! SQLite `meta` table and deleting `migrations.json`. Doing so requires a
-//! refactor of the migration runner (`migration::mod`), which currently
-//! reads/writes `migrations.json` exclusively. The simpler design — adopted
-//! here — is to leave `migrations.json` as the canonical migration-state
-//! location indefinitely. The `meta` table exists in the schema for future
-//! SQLite-only metadata but is unused by this migration.
+//! Migration execution is tracked in the `schema_migrations` table inside
+//! `acs.db` (owned by the migration runner, see `migration::mod`).
+//! `migrations.json` is the legacy tracking file: the runner reads it one
+//! time to backfill the tracking table on databases that predate it, and
+//! never writes it again. This migration leaves the file untouched. The
+//! `meta` table exists in the schema for future SQLite-only metadata but is
+//! unused by this migration.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -64,9 +68,20 @@ impl Migration for JsonToSqlite {
         let workflows_path = data_dir.join("workflows.json");
         let runs_dir = data_dir.join("runs");
 
-        // 1. acs.db already exists → already applied.
+        // 1. A `workflows` table in acs.db means the conversion (or the
+        //    fresh-install schema) is already in place. Table-based rather
+        //    than file-based: the migration runner creates acs.db up front to
+        //    host its `schema_migrations` tracking table, so the file may
+        //    exist before this migration has ever run.
         if db_path.exists() {
-            return Ok(false);
+            let db_path_check = db_path.clone();
+            let has_workflows_table =
+                tokio::task::spawn_blocking(move || workflows_table_exists(&db_path_check))
+                    .await
+                    .map_err(|e| AcsError::Internal(format!("blocking task failed: {}", e)))??;
+            if has_workflows_table {
+                return Ok(false);
+            }
         }
 
         // 2. Fresh install: no JSON sources to read. Create the schema-only
@@ -170,7 +185,11 @@ impl Migration for JsonToSqlite {
                 // from a clean slate. The transaction was already rolled
                 // back inside `migrate_blocking`; the file removal here
                 // covers the case where the connection had already been
-                // opened (so the file exists on disk).
+                // opened (so the file exists on disk). Removing the file also
+                // drops the runner's schema_migrations rows — that is safe:
+                // the runner recreates the table immediately when it records
+                // this failure, and any earlier migrations simply re-run as
+                // no-ops on the next startup.
                 let _ = std::fs::remove_file(&db_path);
                 // Also remove any WAL sidecars that may have been created.
                 let _ = std::fs::remove_file(data_dir.join("acs.db-wal"));
@@ -179,6 +198,21 @@ impl Migration for JsonToSqlite {
             }
         }
     }
+}
+
+/// Return `true` when `acs.db` at `path` contains a `workflows` table — the
+/// marker that the conversion (or the fresh-install schema) already happened.
+fn workflows_table_exists(path: &Path) -> Result<bool, AcsError> {
+    let conn = Connection::open(path)
+        .map_err(|e| AcsError::Storage(format!("Failed to open SQLite at {:?}: {}", path, e)))?;
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'workflows'",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(|e| AcsError::Storage(format!("Failed to inspect sqlite_master: {}", e)))?;
+    Ok(n > 0)
 }
 
 // ─── JSON readers ─────────────────────────────────────────────────────────────

--- a/acs/src/migration/m002_json_to_sqlite.rs
+++ b/acs/src/migration/m002_json_to_sqlite.rs
@@ -635,6 +635,7 @@ mod tests {
             schedule_mode: ScheduleMode::default(),
             enabled: true,
             is_favorited: false,
+            deleted: false,
             steps: vec![make_shell_step("step-1")],
             default_input: Some(serde_json::json!({"k": 1})),
             working_dir: Some("/tmp".to_string()),

--- a/acs/src/migration/m008_add_workflow_deleted.rs
+++ b/acs/src/migration/m008_add_workflow_deleted.rs
@@ -1,0 +1,236 @@
+//! Migration 008 — add the `deleted` soft-delete column to the `workflows`
+//! table.
+//!
+//! # Background
+//!
+//! v4.2.14 (ACS-25) switches `DELETE /api/workflows/{id}` from a hard delete
+//! (which failed with a FOREIGN KEY constraint error whenever the workflow had
+//! run history) to a **soft delete**. The workflow row and all of its
+//! `workflow_runs` are kept — the run rows *are* the cost/token record — and
+//! the workflow is simply flagged `deleted = 1`.
+//!
+//! # What this migration does
+//!
+//! If `acs.db` does not exist → return `Ok(false)` (fresh install — the column
+//! is present from the start via `schema.rs`).
+//!
+//! If the `deleted` column already exists in `workflows` → return `Ok(false)`
+//! (idempotent).
+//!
+//! Otherwise:
+//! ```sql
+//! ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;
+//! ```
+//!
+//! Existing workflows keep `deleted = 0` (the correct "not deleted" sentinel).
+//! No table rebuild, no new tables, no foreign-key changes.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use rusqlite::Connection;
+
+use crate::errors::AcsError;
+use crate::migration::Migration;
+use crate::storage::sqlite;
+
+pub struct AddWorkflowDeleted;
+
+#[async_trait]
+impl Migration for AddWorkflowDeleted {
+    fn name(&self) -> &'static str {
+        "m008_add_workflow_deleted"
+    }
+
+    async fn run(&self, data_dir: &Path) -> Result<bool, AcsError> {
+        let db_path = data_dir.join("acs.db");
+        if !db_path.exists() {
+            return Ok(false);
+        }
+        let db_path_clone = db_path.clone();
+        tokio::task::spawn_blocking(move || run_blocking(&db_path_clone))
+            .await
+            .map_err(|e| AcsError::Internal(format!("blocking task failed: {}", e)))?
+    }
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool, AcsError> {
+    // PRAGMA table_info returns one row per column with fields:
+    //   cid | name | type | notnull | dflt_value | pk
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({})", table))
+        .map_err(|e| AcsError::Storage(format!("Failed to prepare PRAGMA table_info: {}", e)))?;
+
+    let names: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| AcsError::Storage(format!("Failed to query PRAGMA table_info: {}", e)))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AcsError::Storage(format!("Failed to collect column names: {}", e)))?;
+
+    Ok(names.iter().any(|n| n == column))
+}
+
+fn run_blocking(db_path: &Path) -> Result<bool, AcsError> {
+    let conn = sqlite::open_with_schema(db_path)?;
+
+    // Idempotency check: if the column already exists, nothing to do.
+    if column_exists(&conn, "workflows", "deleted")? {
+        return Ok(false);
+    }
+
+    conn.execute(
+        "ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
+        [],
+    )
+    .map_err(|e| AcsError::Storage(format!("ALTER TABLE failed: {}", e)))?;
+
+    tracing::info!("Migration m008 complete: added `deleted` column to workflows");
+    Ok(true)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    /// Apply the pre-m008 `workflows` schema (no `deleted` column) to a raw
+    /// connection so the migration has something to migrate.
+    fn apply_old_schema(conn: &Connection) {
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA foreign_keys = ON;
+             PRAGMA synchronous = NORMAL;
+             CREATE TABLE IF NOT EXISTS workflows (
+                 id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+                 version INTEGER NOT NULL, schedule TEXT NOT NULL,
+                 timezone TEXT, schedule_mode TEXT NOT NULL,
+                 enabled INTEGER NOT NULL, steps_json TEXT NOT NULL,
+                 default_input TEXT, working_dir TEXT, env_vars TEXT,
+                 allow_concurrent INTEGER NOT NULL, on_failure TEXT NOT NULL,
+                 last_run_at TEXT, last_run_status TEXT, last_run_id TEXT,
+                 created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+                 is_favorited INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE IF NOT EXISTS workflow_runs (
+                 run_id TEXT PRIMARY KEY, workflow_id TEXT NOT NULL,
+                 workflow_version INTEGER NOT NULL, workflow_snapshot TEXT NOT NULL,
+                 started_at TEXT NOT NULL, finished_at TEXT,
+                 status TEXT NOT NULL, trigger_input TEXT,
+                 steps_json TEXT NOT NULL, total_cost_usd REAL,
+                 total_duration_ms INTEGER,
+                 total_input_tokens INTEGER NOT NULL DEFAULT 0,
+                 total_output_tokens INTEGER NOT NULL DEFAULT 0,
+                 FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+             );
+             CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+        )
+        .expect("apply old schema");
+    }
+
+    // ── Test 1: no acs.db → no-op ────────────────────────────────────────────
+    #[tokio::test]
+    async fn test_no_db_file_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let m = AddWorkflowDeleted;
+        let did_work = m.run(tmp.path()).await.expect("migrate");
+        assert!(!did_work, "missing acs.db must be a no-op");
+    }
+
+    // ── Test 2: fresh (old) DB → adds the column, default 0 ──────────────────
+    #[tokio::test]
+    async fn test_adds_column_with_default_false() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("acs.db");
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            apply_old_schema(&conn);
+            // Insert an existing workflow to prove it survives the migration.
+            conn.execute(
+                "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
+                 enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at) \
+                 VALUES ('id-1', 'legacy', 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', \
+                 '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+                [],
+            )
+            .expect("insert legacy row");
+            assert!(
+                !column_exists(&conn, "workflows", "deleted").unwrap(),
+                "column must not exist before migration"
+            );
+        }
+
+        let m = AddWorkflowDeleted;
+        let did_work = m.run(tmp.path()).await.expect("migrate");
+        assert!(
+            did_work,
+            "migration must do work on a DB without the column"
+        );
+
+        let conn = sqlite::open_with_schema(&db_path).expect("reopen");
+        assert!(
+            column_exists(&conn, "workflows", "deleted").unwrap(),
+            "deleted column must exist after migration"
+        );
+        // Existing workflow must be unaffected: deleted defaults to 0.
+        let deleted: i64 = conn
+            .query_row("SELECT deleted FROM workflows WHERE id = 'id-1'", [], |r| {
+                r.get(0)
+            })
+            .expect("read deleted");
+        assert_eq!(deleted, 0, "existing workflow must default to deleted = 0");
+    }
+
+    // ── Test 3: already migrated → idempotent (Ok(false)) ────────────────────
+    #[tokio::test]
+    async fn test_idempotent_if_column_present() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("acs.db");
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            apply_old_schema(&conn);
+        }
+
+        let m = AddWorkflowDeleted;
+        assert!(m.run(tmp.path()).await.expect("first run"), "first adds");
+        assert!(
+            !m.run(tmp.path()).await.expect("second run"),
+            "second run must be a no-op"
+        );
+    }
+
+    // ── Test 4: column type + NOT NULL + DEFAULT 0 ───────────────────────────
+    #[tokio::test]
+    async fn test_column_type_and_default() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("acs.db");
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            apply_old_schema(&conn);
+        }
+        AddWorkflowDeleted.run(tmp.path()).await.expect("migrate");
+
+        let conn = sqlite::open_with_schema(&db_path).expect("reopen");
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(workflows)")
+            .expect("prepare PRAGMA");
+        let row = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(1)?,                    // name
+                    r.get::<_, String>(2)?,                    // type
+                    r.get::<_, i64>(3)?,                       // notnull
+                    r.get::<_, String>(4).unwrap_or_default(), // dflt_value
+                ))
+            })
+            .expect("query PRAGMA")
+            .filter_map(|r| r.ok())
+            .find(|(name, _, _, _)| name == "deleted")
+            .expect("deleted column present");
+        assert_eq!(row.1.to_uppercase(), "INTEGER", "type mismatch");
+        assert_eq!(row.2, 1, "must be NOT NULL");
+        assert_eq!(row.3, "0", "default must be 0");
+    }
+}

--- a/acs/src/migration/m008_add_workflow_deleted.rs
+++ b/acs/src/migration/m008_add_workflow_deleted.rs
@@ -1,10 +1,10 @@
-//! Migration 008 — soft-delete support on the `workflows` table (ACS-25,
-//! v4.2.14): add the `deleted` column and replace the inline `UNIQUE`
+//! Migration 008 — soft-delete support on the `workflows` table:
+//! add the `deleted` column and replace the inline `UNIQUE`
 //! constraint on `name` with a **partial unique index** over live rows.
 //!
 //! # Background
 //!
-//! v4.2.14 switches `DELETE /api/workflows/{id}` from a hard delete (which
+//! `DELETE /api/workflows/{id}` switched from a hard delete (which
 //! failed with a FOREIGN KEY constraint error whenever the workflow had run
 //! history) to a **soft delete**. The workflow row and all of its
 //! `workflow_runs` are kept — the run rows *are* the cost/token record — and

--- a/acs/src/migration/m008_add_workflow_deleted.rs
+++ b/acs/src/migration/m008_add_workflow_deleted.rs
@@ -1,38 +1,52 @@
-//! Migration 008 — add the `deleted` soft-delete column to the `workflows`
-//! table.
+//! Migration 008 — soft-delete support on the `workflows` table (ACS-25,
+//! v4.2.14): add the `deleted` column and replace the inline `UNIQUE`
+//! constraint on `name` with a **partial unique index** over live rows.
 //!
 //! # Background
 //!
-//! v4.2.14 (ACS-25) switches `DELETE /api/workflows/{id}` from a hard delete
-//! (which failed with a FOREIGN KEY constraint error whenever the workflow had
-//! run history) to a **soft delete**. The workflow row and all of its
+//! v4.2.14 switches `DELETE /api/workflows/{id}` from a hard delete (which
+//! failed with a FOREIGN KEY constraint error whenever the workflow had run
+//! history) to a **soft delete**. The workflow row and all of its
 //! `workflow_runs` are kept — the run rows *are* the cost/token record — and
-//! the workflow is simply flagged `deleted = 1`.
+//! the workflow is simply flagged `deleted = 1`, keeping its name verbatim.
+//!
+//! Name uniqueness must then hold among **live** workflows only, so the old
+//! inline `UNIQUE` on `workflows.name` (which SQLite cannot drop in place) is
+//! removed via a standard table rebuild and replaced with:
+//!
+//! ```sql
+//! CREATE UNIQUE INDEX idx_workflows_name_live ON workflows(name) WHERE deleted = 0;
+//! ```
 //!
 //! # What this migration does
 //!
-//! If `acs.db` does not exist → return `Ok(false)` (fresh install — the column
-//! is present from the start via `schema.rs`).
+//! If `acs.db` does not exist → return `Ok(false)` (fresh install — the new
+//! table shape and index come from `schema.rs`).
 //!
-//! If the `deleted` column already exists in `workflows` → return `Ok(false)`
-//! (idempotent).
+//! If the `workflows` table DDL no longer contains `UNIQUE` → return
+//! `Ok(false)` (idempotent; already rebuilt or created fresh).
 //!
-//! Otherwise:
-//! ```sql
-//! ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;
-//! ```
+//! Otherwise (standard SQLite rebuild, in one transaction with
+//! `foreign_keys = OFF` for its duration):
 //!
-//! Existing workflows keep `deleted = 0` (the correct "not deleted" sentinel).
-//! No table rebuild, no new tables, no foreign-key changes.
+//! 1. Additively `ALTER TABLE` any columns the old table may lack
+//!    (`is_favorited`, `deleted`) so the copy below is column-stable.
+//! 2. `CREATE TABLE workflows_new (...)` — same shape, **no** inline `UNIQUE`.
+//! 3. Copy all rows.
+//! 4. `DROP TABLE workflows;` then `ALTER TABLE workflows_new RENAME TO workflows;`
+//! 5. `CREATE UNIQUE INDEX idx_workflows_name_live ON workflows(name) WHERE deleted = 0;`
+//! 6. `PRAGMA foreign_key_check` — abort (rollback) if the rebuild broke the
+//!    `workflow_runs.workflow_id` FK.
+//!
+//! Existing workflows keep `deleted = 0` and their original names verbatim.
 
 use std::path::Path;
 
 use async_trait::async_trait;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 
 use crate::errors::AcsError;
 use crate::migration::Migration;
-use crate::storage::sqlite;
 
 pub struct AddWorkflowDeleted;
 
@@ -54,38 +68,132 @@ impl Migration for AddWorkflowDeleted {
     }
 }
 
-fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool, AcsError> {
-    // PRAGMA table_info returns one row per column with fields:
-    //   cid | name | type | notnull | dflt_value | pk
-    let mut stmt = conn
-        .prepare(&format!("PRAGMA table_info({})", table))
-        .map_err(|e| AcsError::Storage(format!("Failed to prepare PRAGMA table_info: {}", e)))?;
-
-    let names: Vec<String> = stmt
-        .query_map([], |row| row.get::<_, String>(1))
-        .map_err(|e| AcsError::Storage(format!("Failed to query PRAGMA table_info: {}", e)))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| AcsError::Storage(format!("Failed to collect column names: {}", e)))?;
-
-    Ok(names.iter().any(|n| n == column))
-}
-
 fn run_blocking(db_path: &Path) -> Result<bool, AcsError> {
-    let conn = sqlite::open_with_schema(db_path)?;
+    // Open raw: do NOT run `apply_schema` here — its partial-index statement
+    // must not race the rebuild, and this migration is self-contained.
+    let mut conn = Connection::open(db_path)
+        .map_err(|e| AcsError::Storage(format!("Failed to open SQLite at {:?}: {}", db_path, e)))?;
 
-    // Idempotency check: if the column already exists, nothing to do.
-    if column_exists(&conn, "workflows", "deleted")? {
+    // Idempotency: rebuilt (or fresh) tables have no inline UNIQUE in their DDL.
+    let ddl: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'workflows'",
+            [],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(|e| AcsError::Storage(format!("Failed to read workflows DDL: {}", e)))?;
+    let ddl = match ddl {
+        // No workflows table at all — nothing to rebuild; `apply_schema` will
+        // create the fresh shape at daemon startup.
+        None => return Ok(false),
+        Some(d) => d,
+    };
+    if !ddl.to_uppercase().contains("UNIQUE") {
         return Ok(false);
     }
 
-    conn.execute(
+    // The rebuild copies an explicit column list, so make sure the columns
+    // added after the original CREATE TABLE exist on the old table too.
+    for sql in [
+        "ALTER TABLE workflows ADD COLUMN is_favorited INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
-        [],
-    )
-    .map_err(|e| AcsError::Storage(format!("ALTER TABLE failed: {}", e)))?;
+    ] {
+        if let Err(e) = conn.execute(sql, []) {
+            if !e.to_string().contains("duplicate column name") {
+                return Err(AcsError::Storage(format!(
+                    "Additive column add failed ({}): {}",
+                    sql, e
+                )));
+            }
+        }
+    }
 
-    tracing::info!("Migration m008 complete: added `deleted` column to workflows");
+    // FK enforcement must be off while the parent table is dropped/renamed.
+    // PRAGMA foreign_keys is a no-op inside a transaction, so toggle outside.
+    conn.execute_batch("PRAGMA foreign_keys = OFF;")
+        .map_err(|e| AcsError::Storage(format!("Failed to disable foreign_keys: {}", e)))?;
+
+    let result = rebuild_workflows_table(&mut conn);
+    // Best-effort re-enable regardless of outcome; the connection is dropped
+    // right after, and every production connection sets its own pragmas.
+    let _ = conn.execute_batch("PRAGMA foreign_keys = ON;");
+    result?;
+
+    tracing::info!(
+        "Migration m008 complete: workflows rebuilt without inline UNIQUE(name); \
+         added `deleted` column and partial unique index idx_workflows_name_live"
+    );
     Ok(true)
+}
+
+fn rebuild_workflows_table(conn: &mut Connection) -> Result<(), AcsError> {
+    let tx = conn
+        .transaction()
+        .map_err(|e| AcsError::Storage(format!("Failed to start transaction: {}", e)))?;
+
+    tx.execute_batch(
+        r#"
+        CREATE TABLE workflows_new (
+            id                  TEXT PRIMARY KEY,
+            name                TEXT NOT NULL,
+            version             INTEGER NOT NULL,
+            schedule            TEXT NOT NULL,
+            timezone            TEXT,
+            schedule_mode       TEXT NOT NULL,
+            enabled             INTEGER NOT NULL,
+            steps_json          TEXT NOT NULL,
+            default_input       TEXT,
+            working_dir         TEXT,
+            env_vars            TEXT,
+            allow_concurrent    INTEGER NOT NULL,
+            on_failure          TEXT NOT NULL,
+            last_run_at         TEXT,
+            last_run_status     TEXT,
+            last_run_id         TEXT,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL,
+            is_favorited        INTEGER NOT NULL DEFAULT 0,
+            deleted             INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO workflows_new (
+            id, name, version, schedule, timezone, schedule_mode, enabled,
+            steps_json, default_input, working_dir, env_vars,
+            allow_concurrent, on_failure, last_run_at, last_run_status,
+            last_run_id, created_at, updated_at, is_favorited, deleted
+        )
+        SELECT
+            id, name, version, schedule, timezone, schedule_mode, enabled,
+            steps_json, default_input, working_dir, env_vars,
+            allow_concurrent, on_failure, last_run_at, last_run_status,
+            last_run_id, created_at, updated_at, is_favorited, deleted
+        FROM workflows;
+        DROP TABLE workflows;
+        ALTER TABLE workflows_new RENAME TO workflows;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_workflows_name_live
+            ON workflows(name) WHERE deleted = 0;
+        "#,
+    )
+    .map_err(|e| AcsError::Storage(format!("workflows table rebuild failed: {}", e)))?;
+
+    // Sanity: the rebuild must not have orphaned any workflow_runs rows.
+    let violations: i64 = tx
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_foreign_key_check('workflow_runs')",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(|e| AcsError::Storage(format!("foreign_key_check failed: {}", e)))?;
+    if violations > 0 {
+        return Err(AcsError::Storage(format!(
+            "workflows rebuild would leave {} foreign-key violation(s); rolling back",
+            violations
+        )));
+    }
+
+    tx.commit()
+        .map_err(|e| AcsError::Storage(format!("COMMIT failed: {}", e)))?;
+    Ok(())
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -96,8 +204,8 @@ mod tests {
     use rusqlite::Connection;
     use tempfile::TempDir;
 
-    /// Apply the pre-m008 `workflows` schema (no `deleted` column) to a raw
-    /// connection so the migration has something to migrate.
+    /// Apply the pre-m008 schema (inline UNIQUE on name, no `deleted` column)
+    /// to a raw connection so the migration has something to rebuild.
     fn apply_old_schema(conn: &Connection) {
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
@@ -130,6 +238,38 @@ mod tests {
         .expect("apply old schema");
     }
 
+    fn insert_workflow(conn: &Connection, id: &str, name: &str) {
+        conn.execute(
+            "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
+             enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at) \
+             VALUES (?, ?, 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', \
+             '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+            [id, name],
+        )
+        .expect("insert workflow");
+    }
+
+    fn workflows_ddl(conn: &Connection) -> String {
+        conn.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'workflows'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read DDL")
+    }
+
+    fn live_name_index_exists(conn: &Connection) -> bool {
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'index' AND name = 'idx_workflows_name_live'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("query index");
+        n == 1
+    }
+
     // ── Test 1: no acs.db → no-op ────────────────────────────────────────────
     #[tokio::test]
     async fn test_no_db_file_returns_false() {
@@ -139,53 +279,66 @@ mod tests {
         assert!(!did_work, "missing acs.db must be a no-op");
     }
 
-    // ── Test 2: fresh (old) DB → adds the column, default 0 ──────────────────
+    // ── Test 2: old DB → rebuild drops inline UNIQUE, adds column + index,
+    //           preserves rows and FK integrity ──────────────────────────────
     #[tokio::test]
-    async fn test_adds_column_with_default_false() {
+    async fn test_rebuild_removes_unique_adds_column_and_index() {
         let tmp = TempDir::new().unwrap();
         let db_path = tmp.path().join("acs.db");
         {
             let conn = Connection::open(&db_path).expect("open");
             apply_old_schema(&conn);
-            // Insert an existing workflow to prove it survives the migration.
+            insert_workflow(&conn, "id-1", "legacy");
+            // A child run referencing the workflow — FK must survive the rebuild.
             conn.execute(
-                "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
-                 enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at) \
-                 VALUES ('id-1', 'legacy', 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', \
-                 '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+                "INSERT INTO workflow_runs (run_id, workflow_id, workflow_version, \
+                 workflow_snapshot, started_at, status, steps_json) \
+                 VALUES ('run-1', 'id-1', 1, '{}', '2025-01-01T00:00:00Z', 'Completed', '[]')",
                 [],
             )
-            .expect("insert legacy row");
+            .expect("insert child run");
             assert!(
-                !column_exists(&conn, "workflows", "deleted").unwrap(),
-                "column must not exist before migration"
+                workflows_ddl(&conn).to_uppercase().contains("UNIQUE"),
+                "precondition: old table has inline UNIQUE"
             );
         }
 
         let m = AddWorkflowDeleted;
         let did_work = m.run(tmp.path()).await.expect("migrate");
-        assert!(
-            did_work,
-            "migration must do work on a DB without the column"
-        );
+        assert!(did_work, "migration must rebuild an old-shape table");
 
-        let conn = sqlite::open_with_schema(&db_path).expect("reopen");
+        let conn = Connection::open(&db_path).expect("reopen");
+        // Inline UNIQUE gone; partial index present.
         assert!(
-            column_exists(&conn, "workflows", "deleted").unwrap(),
-            "deleted column must exist after migration"
+            !workflows_ddl(&conn).to_uppercase().contains("UNIQUE"),
+            "inline UNIQUE must be gone after the rebuild"
         );
-        // Existing workflow must be unaffected: deleted defaults to 0.
-        let deleted: i64 = conn
-            .query_row("SELECT deleted FROM workflows WHERE id = 'id-1'", [], |r| {
+        assert!(
+            live_name_index_exists(&conn),
+            "idx_workflows_name_live must exist after the rebuild"
+        );
+        // Row preserved, name verbatim, deleted defaults to 0.
+        let (name, deleted): (String, i64) = conn
+            .query_row(
+                "SELECT name, deleted FROM workflows WHERE id = 'id-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("read migrated row");
+        assert_eq!(name, "legacy");
+        assert_eq!(deleted, 0);
+        // FK integrity intact.
+        let violations: i64 = conn
+            .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |r| {
                 r.get(0)
             })
-            .expect("read deleted");
-        assert_eq!(deleted, 0, "existing workflow must default to deleted = 0");
+            .expect("fk check");
+        assert_eq!(violations, 0, "rebuild must not break the workflow_runs FK");
     }
 
     // ── Test 3: already migrated → idempotent (Ok(false)) ────────────────────
     #[tokio::test]
-    async fn test_idempotent_if_column_present() {
+    async fn test_idempotent_after_rebuild() {
         let tmp = TempDir::new().unwrap();
         let db_path = tmp.path().join("acs.db");
         {
@@ -194,14 +347,47 @@ mod tests {
         }
 
         let m = AddWorkflowDeleted;
-        assert!(m.run(tmp.path()).await.expect("first run"), "first adds");
+        assert!(
+            m.run(tmp.path()).await.expect("first run"),
+            "first run rebuilds"
+        );
         assert!(
             !m.run(tmp.path()).await.expect("second run"),
             "second run must be a no-op"
         );
     }
 
-    // ── Test 4: column type + NOT NULL + DEFAULT 0 ───────────────────────────
+    // ── Test 4: post-migration semantics — deleted rows exempt from the
+    //           name-uniqueness index, live duplicates still rejected ─────────
+    #[tokio::test]
+    async fn test_post_migration_name_reuse_semantics() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("acs.db");
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            apply_old_schema(&conn);
+            insert_workflow(&conn, "id-1", "reuse-me");
+        }
+        AddWorkflowDeleted.run(tmp.path()).await.expect("migrate");
+
+        let conn = Connection::open(&db_path).expect("reopen");
+        // Soft-delete the migrated row (name kept verbatim).
+        conn.execute("UPDATE workflows SET deleted = 1 WHERE id = 'id-1'", [])
+            .expect("soft delete");
+        // A new live row with the same name must now be allowed.
+        insert_workflow(&conn, "id-2", "reuse-me");
+        // But a second LIVE row with that name must still conflict.
+        let dup = conn.execute(
+            "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
+             enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at) \
+             VALUES ('id-3', 'reuse-me', 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', \
+             '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+            [],
+        );
+        assert!(dup.is_err(), "duplicate live name must be rejected");
+    }
+
+    // ── Test 5: deleted column shape (INTEGER NOT NULL DEFAULT 0) ────────────
     #[tokio::test]
     async fn test_column_type_and_default() {
         let tmp = TempDir::new().unwrap();
@@ -212,7 +398,7 @@ mod tests {
         }
         AddWorkflowDeleted.run(tmp.path()).await.expect("migrate");
 
-        let conn = sqlite::open_with_schema(&db_path).expect("reopen");
+        let conn = Connection::open(&db_path).expect("reopen");
         let mut stmt = conn
             .prepare("PRAGMA table_info(workflows)")
             .expect("prepare PRAGMA");

--- a/acs/src/migration/mod.rs
+++ b/acs/src/migration/mod.rs
@@ -1,23 +1,58 @@
-//! Numbered migration system for the Agent Cron Scheduler.
+//! Numbered migration system with database-backed run tracking.
 //!
 //! # Design
 //!
 //! Each migration is a numbered file: `mNNN_<name>.rs` (the `m` prefix is
 //! required because Rust module names cannot start with a digit). The struct
-//! inside implements the [`Migration`] trait, and is registered in the
-//! [`registry`] function in order.
+//! inside implements the [`Migration`] trait, and is registered **in order**
+//! in the [`registry`] function.
 //!
-//! Applied migration names are tracked in `<data_dir>/migrations.json`:
+//! Execution is tracked by name in a `schema_migrations` table inside
+//! `<data_dir>/acs.db`. The table is created by the runner itself — not by a
+//! migration — before any migration logic runs:
 //!
-//! ```json
-//! { "applied": ["m001_jobs_to_workflows"] }
+//! ```sql
+//! CREATE TABLE schema_migrations (
+//!     name        TEXT PRIMARY KEY,
+//!     applied_at  TEXT NOT NULL,
+//!     status      TEXT NOT NULL CHECK (status IN ('success','failed')),
+//!     duration_ms INTEGER,
+//!     error       TEXT
+//! );
 //! ```
 //!
-//! At daemon startup, call [`run_pending`] to execute any migrations that have
-//! not yet been applied. Each migration's [`Migration::run`] returns
-//! `Ok(true)` when it did work, or `Ok(false)` when it determined there was
-//! nothing to do (idempotent). The runner only adds the migration to the
-//! applied set when `run` returns `Ok(true)`.
+//! # Runner semantics
+//!
+//! [`run_pending`] walks the registry in order. The tracking table — and only
+//! the tracking table — decides what executes:
+//!
+//! - **no row** → run the migration, then record `success` or `failed`;
+//! - **`success` row** → skip without invoking the migration;
+//! - **`failed` row** → abort startup with an error naming the migration.
+//!   The sanctioned recovery workflow is: fix the underlying issue, then
+//!   delete the row (`DELETE FROM schema_migrations WHERE name = '<name>';`)
+//!   so the next startup re-runs it.
+//!
+//! A migration that runs but finds nothing to do still records `success` —
+//! the row means "processed", so it never re-runs. Each migration keeps its
+//! own internal idempotency checks purely as a safety property: they make
+//! delete-row-and-re-run harmless, but the runner never consults them to
+//! decide execution.
+//!
+//! When a migration fails, its row is recorded with status `failed` and the
+//! error text, and the runner aborts immediately — later migrations do not
+//! run and get no row.
+//!
+//! # Backfill for databases that predate the tracking table
+//!
+//! Older installs recorded applied migrations in `<data_dir>/migrations.json`.
+//! The first time the runner creates the tracking table it seeds a `success`
+//! row for every registry migration named in that file — those are treated as
+//! already applied without being invoked. Every other migration then runs
+//! normally; on an already-migrated database their internal idempotency makes
+//! that a safe no-op, which is recorded as `success`. After this one-time
+//! backfill the table is the sole source of truth; `migrations.json` is left
+//! on disk but never written again.
 //!
 //! # Adding a new migration
 //!
@@ -36,10 +71,12 @@ mod m007_add_token_columns;
 mod m008_add_workflow_deleted;
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use rusqlite::{Connection, OptionalExtension};
+use serde::Deserialize;
 
 use crate::errors::AcsError;
 
@@ -48,8 +85,8 @@ use crate::errors::AcsError;
 /// A single forward migration step.
 ///
 /// Each migration lives in a numbered file (`mNNN_<name>.rs`). The name must
-/// be stable — it is used as the identifier in the applied-migrations state
-/// file and must never be changed after it ships.
+/// be stable — it is the primary key in the `schema_migrations` tracking
+/// table and must never be changed after it ships.
 #[async_trait]
 pub trait Migration: Send + Sync {
     /// The stable migration name, e.g. `"m001_jobs_to_workflows"`.
@@ -57,12 +94,14 @@ pub trait Migration: Send + Sync {
 
     /// Run the migration against the given data directory.
     ///
-    /// **Idempotent contract**: re-running on already-migrated data must be a
-    /// no-op. The implementation is responsible for detecting that it has
-    /// already been applied (e.g., checking for the output file).
-    ///
     /// Returns `Ok(true)` if the migration performed work, `Ok(false)` if it
-    /// determined there was nothing to do (already applied or not needed).
+    /// determined there was nothing to do. The runner records `success`
+    /// either way — the return value is informational (logging) only.
+    ///
+    /// **Idempotency**: re-running on already-migrated data must be a no-op.
+    /// The runner does not rely on this to decide execution (the tracking
+    /// table does), but it is what makes the delete-row-and-re-run recovery
+    /// workflow safe.
     async fn run(&self, data_dir: &Path) -> Result<bool, AcsError>;
 }
 
@@ -87,43 +126,233 @@ fn registry() -> Vec<Box<dyn Migration>> {
 /// Summary returned by [`run_pending`].
 #[derive(Debug, Default)]
 pub struct MigrationRunReport {
-    /// Migrations that were already in the applied set — skipped entirely.
-    pub already_applied: Vec<String>,
-    /// Migrations that ran and returned `Ok(true)` — work was done.
-    pub newly_applied: Vec<String>,
-    /// Migrations that ran and returned `Ok(false)` — nothing to do.
-    pub skipped_not_needed: Vec<String>,
+    /// Backfilled as `success` from the legacy `migrations.json` state when
+    /// the tracking table was first created. Not invoked.
+    pub seeded: Vec<String>,
+    /// Skipped because the tracking table already records them as `success`.
+    /// Not invoked.
+    pub skipped: Vec<String>,
+    /// Invoked and performed work. Recorded as `success`.
+    pub ran: Vec<String>,
+    /// Invoked but found nothing to do. Still recorded as `success`.
+    pub ran_no_op: Vec<String>,
+}
+
+// ── Tracking table access ─────────────────────────────────────────────────────
+
+const TRACKING_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS schema_migrations (
+    name        TEXT PRIMARY KEY,
+    applied_at  TEXT NOT NULL,
+    status      TEXT NOT NULL CHECK (status IN ('success','failed')),
+    duration_ms INTEGER,
+    error       TEXT
+)";
+
+/// Open the tracking database, creating the file and the `schema_migrations`
+/// table if they do not exist yet.
+fn open_tracking_db(db_path: &Path) -> Result<Connection, AcsError> {
+    let conn = Connection::open(db_path)
+        .map_err(|e| AcsError::Storage(format!("Failed to open SQLite at {:?}: {}", db_path, e)))?;
+    conn.execute(TRACKING_TABLE_SQL, []).map_err(|e| {
+        AcsError::Storage(format!("Failed to create schema_migrations table: {}", e))
+    })?;
+    Ok(conn)
+}
+
+/// Run a closure against the tracking database on a blocking task. Opens a
+/// fresh connection (creating the table if needed) — these are low-frequency
+/// startup operations, so per-call connections keep the runner simple.
+async fn with_tracking_db<F, T>(db_path: &Path, f: F) -> Result<T, AcsError>
+where
+    F: FnOnce(&Connection) -> Result<T, AcsError> + Send + 'static,
+    T: Send + 'static,
+{
+    let path: PathBuf = db_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let conn = open_tracking_db(&path)?;
+        f(&conn)
+    })
+    .await
+    .map_err(|e| AcsError::Internal(format!("blocking task failed: {}", e)))?
+}
+
+/// Return `true` when the tracking table already exists, **without** creating
+/// the database file or the table. Used to detect a first run so the legacy
+/// backfill happens exactly once.
+async fn tracking_table_present(db_path: &Path) -> Result<bool, AcsError> {
+    if !db_path.exists() {
+        return Ok(false);
+    }
+    let path: PathBuf = db_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let conn = Connection::open(&path).map_err(|e| {
+            AcsError::Storage(format!("Failed to open SQLite at {:?}: {}", path, e))
+        })?;
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'table' AND name = 'schema_migrations'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(|e| AcsError::Storage(format!("Failed to inspect sqlite_master: {}", e)))?;
+        Ok(n > 0)
+    })
+    .await
+    .map_err(|e| AcsError::Internal(format!("blocking task failed: {}", e)))?
+}
+
+/// Fetch the recorded status (`"success"` / `"failed"`) for a migration, or
+/// `None` when it has no row.
+async fn migration_status(db_path: &Path, name: &str) -> Result<Option<String>, AcsError> {
+    let name = name.to_string();
+    with_tracking_db(db_path, move |conn| {
+        conn.query_row(
+            "SELECT status FROM schema_migrations WHERE name = ?",
+            [&name],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|e| AcsError::Storage(format!("Failed to read schema_migrations: {}", e)))
+    })
+    .await
+}
+
+/// Record (or overwrite) a migration's tracking row.
+async fn record_migration(
+    db_path: &Path,
+    name: &str,
+    status: &str,
+    duration_ms: Option<i64>,
+    error: Option<String>,
+) -> Result<(), AcsError> {
+    let name = name.to_string();
+    let status = status.to_string();
+    let applied_at = chrono::Utc::now().to_rfc3339();
+    with_tracking_db(db_path, move |conn| {
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_migrations \
+             (name, applied_at, status, duration_ms, error) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![name, applied_at, status, duration_ms, error],
+        )
+        .map_err(|e| AcsError::Storage(format!("Failed to write schema_migrations: {}", e)))?;
+        Ok(())
+    })
+    .await
+}
+
+/// Insert `success` rows for the given names, skipping any that already have
+/// a row. Used only by the one-time legacy backfill.
+async fn seed_success_rows(db_path: &Path, names: Vec<String>) -> Result<(), AcsError> {
+    let applied_at = chrono::Utc::now().to_rfc3339();
+    with_tracking_db(db_path, move |conn| {
+        for name in &names {
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations \
+                 (name, applied_at, status, duration_ms, error) \
+                 VALUES (?1, ?2, 'success', NULL, NULL)",
+                rusqlite::params![name, applied_at],
+            )
+            .map_err(|e| AcsError::Storage(format!("Failed to seed schema_migrations: {}", e)))?;
+        }
+        Ok(())
+    })
+    .await
 }
 
 // ── Public runner ─────────────────────────────────────────────────────────────
 
-/// Run all pending migrations in order.
-///
-/// Migrations already in the applied set (from `migrations.json`) are skipped.
-/// For each pending migration, [`Migration::run`] is called. If it returns
-/// `Ok(true)` the migration name is added to the applied set and the state
-/// file is written. If `run` returns an error the runner **stops immediately**
-/// and propagates the error — partial progress is preserved in the state file.
+/// Run all pending migrations in order, tracked by the `schema_migrations`
+/// table (see the module documentation for the exact semantics).
 pub async fn run_pending(data_dir: &Path) -> Result<MigrationRunReport, AcsError> {
-    let mut applied = read_state(data_dir).await?;
+    run_with_registry(data_dir, registry()).await
+}
+
+/// Runner core, parameterised over the registry so tests can drive it with
+/// mock migrations.
+async fn run_with_registry(
+    data_dir: &Path,
+    migrations: Vec<Box<dyn Migration>>,
+) -> Result<MigrationRunReport, AcsError> {
+    let db_path = data_dir.join("acs.db");
     let mut report = MigrationRunReport::default();
 
-    for migration in registry() {
-        let name = migration.name().to_string();
+    // Create the tracking table before any migration logic runs. When the
+    // table did not exist yet, this is the first run of the tracked runner
+    // against this data dir — backfill from the legacy state file so
+    // already-applied migrations are not invoked again.
+    let had_tracking_table = tracking_table_present(&db_path).await?;
+    with_tracking_db(&db_path, |_| Ok(())).await?;
 
-        if applied.contains(&name) {
-            report.already_applied.push(name);
-            continue;
-        }
-
-        match migration.run(data_dir).await? {
-            true => {
-                applied.insert(name.clone());
-                write_state(data_dir, &applied).await?;
-                report.newly_applied.push(name);
+    if !had_tracking_table {
+        let legacy_applied = read_legacy_state(data_dir).await?;
+        if !legacy_applied.is_empty() {
+            let seed: Vec<String> = migrations
+                .iter()
+                .map(|m| m.name().to_string())
+                .filter(|n| legacy_applied.contains(n))
+                .collect();
+            if !seed.is_empty() {
+                seed_success_rows(&db_path, seed.clone()).await?;
+                report.seeded = seed;
             }
-            false => {
-                report.skipped_not_needed.push(name);
+        }
+    }
+
+    for migration in &migrations {
+        let name = migration.name().to_string();
+        match migration_status(&db_path, &name).await?.as_deref() {
+            Some("success") => {
+                report.skipped.push(name);
+            }
+            Some(_) => {
+                // A recorded failure blocks startup until an operator
+                // intervenes; silently re-running could compound damage on a
+                // half-migrated database.
+                return Err(AcsError::Internal(format!(
+                    "migration '{}' previously failed and is blocking startup. Fix the \
+                     underlying issue, then delete its tracking row so the next startup \
+                     re-runs it: DELETE FROM schema_migrations WHERE name = '{}'; \
+                     (database: {})",
+                    name,
+                    name,
+                    db_path.display()
+                )));
+            }
+            None => {
+                let started = Instant::now();
+                let outcome = migration.run(data_dir).await;
+                let duration_ms = started.elapsed().as_millis() as i64;
+                match outcome {
+                    Ok(did_work) => {
+                        record_migration(&db_path, &name, "success", Some(duration_ms), None)
+                            .await?;
+                        if did_work {
+                            report.ran.push(name);
+                        } else {
+                            report.ran_no_op.push(name);
+                        }
+                    }
+                    Err(e) => {
+                        let error_text = e.to_string();
+                        record_migration(
+                            &db_path,
+                            &name,
+                            "failed",
+                            Some(duration_ms),
+                            Some(error_text.clone()),
+                        )
+                        .await?;
+                        return Err(AcsError::Internal(format!(
+                            "migration '{}' failed: {}. Startup aborted; later migrations \
+                             were not run. After fixing the underlying issue, delete the \
+                             tracking row so the next startup re-runs it: \
+                             DELETE FROM schema_migrations WHERE name = '{}';",
+                            name, error_text, name
+                        )));
+                    }
+                }
             }
         }
     }
@@ -131,21 +360,23 @@ pub async fn run_pending(data_dir: &Path) -> Result<MigrationRunReport, AcsError
     Ok(report)
 }
 
-// ── State file I/O ────────────────────────────────────────────────────────────
+// ── Legacy state file (read-only, for the one-time backfill) ──────────────────
 
-/// On-disk schema for `migrations.json`.
-#[derive(Debug, Serialize, Deserialize, Default)]
-struct MigrationState {
+/// On-disk shape of the legacy `migrations.json` tracking file.
+#[derive(Debug, Deserialize, Default)]
+struct LegacyMigrationState {
     applied: Vec<String>,
 }
 
-/// Read the applied-migration names from `<data_dir>/migrations.json`.
+/// Read the applied-migration names from the legacy `<data_dir>/migrations.json`.
+/// Used only to backfill the `schema_migrations` table the first time the
+/// tracked runner sees a data dir; the file is never written again.
 ///
 /// - If the file does not exist, returns an empty set (fresh install).
 /// - If the file is corrupt (invalid JSON), logs a warning and returns an
-///   empty set rather than failing — this prevents lockout if the state file
-///   gets corrupted.
-pub async fn read_state(data_dir: &Path) -> Result<HashSet<String>, AcsError> {
+///   empty set — every migration then runs normally, and their internal
+///   idempotency keeps that safe on an already-migrated database.
+async fn read_legacy_state(data_dir: &Path) -> Result<HashSet<String>, AcsError> {
     let path = data_dir.join("migrations.json");
 
     if !path.exists() {
@@ -161,7 +392,7 @@ pub async fn read_state(data_dir: &Path) -> Result<HashSet<String>, AcsError> {
             );
             Ok(HashSet::new())
         }
-        Ok(content) => match serde_json::from_str::<MigrationState>(&content) {
+        Ok(content) => match serde_json::from_str::<LegacyMigrationState>(&content) {
             Ok(state) => Ok(state.applied.into_iter().collect()),
             Err(e) => {
                 tracing::warn!(
@@ -175,319 +406,527 @@ pub async fn read_state(data_dir: &Path) -> Result<HashSet<String>, AcsError> {
     }
 }
 
-/// Persist the applied-migration set to `<data_dir>/migrations.json`.
-///
-/// Uses an atomic write (write to `.tmp`, then rename) to prevent partial
-/// writes from corrupting the state file.
-async fn write_state(data_dir: &Path, applied: &HashSet<String>) -> Result<(), AcsError> {
-    let path = data_dir.join("migrations.json");
-    let tmp_path = data_dir.join("migrations.json.tmp");
-
-    // Sort for deterministic output.
-    let mut sorted: Vec<String> = applied.iter().cloned().collect();
-    sorted.sort();
-
-    let state = MigrationState { applied: sorted };
-    let json = serde_json::to_string_pretty(&state)
-        .map_err(|e| AcsError::Storage(format!("Failed to serialize migration state: {}", e)))?;
-
-    tokio::fs::write(&tmp_path, json.as_bytes())
-        .await
-        .map_err(|e| AcsError::Storage(format!("Failed to write migrations.json.tmp: {}", e)))?;
-
-    tokio::fs::rename(&tmp_path, &path)
-        .await
-        .map_err(|e| AcsError::Storage(format!("Failed to rename migrations.json.tmp: {}", e)))?;
-
-    Ok(())
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // ── Mock migrations ───────────────────────────────────────────────────────
 
-    /// A migration that always reports it did work (applied = true).
-    struct AlwaysApplies {
+    /// What a [`Scripted`] mock does when invoked.
+    #[derive(Clone)]
+    enum Behavior {
+        /// Return `Ok(true)` — "ran and did work".
+        DidWork,
+        /// Return `Ok(false)` — "ran, nothing to do".
+        NoOp,
+        /// Return an error while the flag is `true`, `Ok(true)` afterwards.
+        FailWhile(Arc<AtomicBool>),
+    }
+
+    /// A mock migration that records every invocation into a shared log.
+    struct Scripted {
         name: &'static str,
+        behavior: Behavior,
+        invocations: Arc<Mutex<Vec<String>>>,
     }
 
     #[async_trait]
-    impl Migration for AlwaysApplies {
+    impl Migration for Scripted {
         fn name(&self) -> &'static str {
             self.name
         }
         async fn run(&self, _data_dir: &Path) -> Result<bool, AcsError> {
-            Ok(true)
-        }
-    }
-
-    /// A migration that always reports nothing to do (applied = false).
-    struct NeverNeeded {
-        name: &'static str,
-    }
-
-    #[async_trait]
-    impl Migration for NeverNeeded {
-        fn name(&self) -> &'static str {
-            self.name
-        }
-        async fn run(&self, _data_dir: &Path) -> Result<bool, AcsError> {
-            Ok(false)
-        }
-    }
-
-    /// A migration that always returns an error.
-    struct AlwaysFails {
-        name: &'static str,
-    }
-
-    #[async_trait]
-    impl Migration for AlwaysFails {
-        fn name(&self) -> &'static str {
-            self.name
-        }
-        async fn run(&self, _data_dir: &Path) -> Result<bool, AcsError> {
-            Err(AcsError::Storage("simulated migration failure".to_string()))
-        }
-    }
-
-    /// Run a custom list of migrations (bypasses the real registry).
-    async fn run_migrations(
-        data_dir: &Path,
-        migrations: Vec<Box<dyn Migration>>,
-    ) -> Result<MigrationRunReport, AcsError> {
-        let mut applied = read_state(data_dir).await?;
-        let mut report = MigrationRunReport::default();
-
-        for migration in migrations {
-            let name = migration.name().to_string();
-            if applied.contains(&name) {
-                report.already_applied.push(name);
-                continue;
-            }
-            match migration.run(data_dir).await? {
-                true => {
-                    applied.insert(name.clone());
-                    write_state(data_dir, &applied).await?;
-                    report.newly_applied.push(name);
-                }
-                false => {
-                    report.skipped_not_needed.push(name);
+            self.invocations.lock().unwrap().push(self.name.to_string());
+            match &self.behavior {
+                Behavior::DidWork => Ok(true),
+                Behavior::NoOp => Ok(false),
+                Behavior::FailWhile(flag) => {
+                    if flag.load(Ordering::SeqCst) {
+                        Err(AcsError::Storage("simulated migration failure".to_string()))
+                    } else {
+                        Ok(true)
+                    }
                 }
             }
         }
-        Ok(report)
     }
 
-    // ── State file: read/write round-trip ────────────────────────────────────
+    fn scripted(
+        name: &'static str,
+        behavior: Behavior,
+        log: &Arc<Mutex<Vec<String>>>,
+    ) -> Box<dyn Migration> {
+        Box::new(Scripted {
+            name,
+            behavior,
+            invocations: Arc::clone(log),
+        })
+    }
+
+    // ── Tracking-table helpers for assertions ─────────────────────────────────
+
+    /// Read all rows as (name, status, error), ordered by name.
+    fn tracking_rows(data_dir: &Path) -> Vec<(String, String, Option<String>)> {
+        let conn = Connection::open(data_dir.join("acs.db")).expect("open acs.db");
+        let mut stmt = conn
+            .prepare("SELECT name, status, error FROM schema_migrations ORDER BY name")
+            .expect("prepare");
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect");
+        rows
+    }
+
+    fn delete_row(data_dir: &Path, name: &str) {
+        let conn = Connection::open(data_dir.join("acs.db")).expect("open acs.db");
+        conn.execute("DELETE FROM schema_migrations WHERE name = ?", [name])
+            .expect("delete row");
+    }
+
+    fn write_legacy_state(data_dir: &Path, applied: &[&str]) {
+        let json = serde_json::json!({ "applied": applied }).to_string();
+        std::fs::write(data_dir.join("migrations.json"), json).expect("write migrations.json");
+    }
+
+    // ── Legacy state file reading ──────────────────────────────────────────────
 
     #[tokio::test]
-    async fn test_state_read_empty_when_no_file() {
+    async fn test_legacy_state_read_empty_when_no_file() {
         let tmp = TempDir::new().unwrap();
-        let state = read_state(tmp.path()).await.unwrap();
+        let state = read_legacy_state(tmp.path()).await.unwrap();
         assert!(state.is_empty());
     }
 
     #[tokio::test]
-    async fn test_state_write_then_read_round_trips() {
+    async fn test_legacy_state_corruption_treated_as_empty() {
         let tmp = TempDir::new().unwrap();
-        let mut set = HashSet::new();
-        set.insert("m001_foo".to_string());
-        set.insert("m002_bar".to_string());
-
-        write_state(tmp.path(), &set).await.unwrap();
-
-        let loaded = read_state(tmp.path()).await.unwrap();
-        assert_eq!(loaded, set);
-    }
-
-    // ── State file: corruption tolerance ─────────────────────────────────────
-
-    #[tokio::test]
-    async fn test_run_pending_state_file_corruption_treated_as_empty() {
-        let tmp = TempDir::new().unwrap();
-        // Write deliberately corrupt JSON.
         tokio::fs::write(tmp.path().join("migrations.json"), b"not valid json {{{{")
             .await
             .unwrap();
-
-        // read_state should tolerate the corruption and return an empty set.
-        let state = read_state(tmp.path()).await.unwrap();
+        let state = read_legacy_state(tmp.path()).await.unwrap();
         assert!(
             state.is_empty(),
             "corrupt state file should be treated as empty"
         );
     }
 
-    // ── Runner: all migrations run on a fresh install ─────────────────────────
+    // ── Fresh run: everything runs once, then everything skips ────────────────
 
     #[tokio::test]
-    async fn test_run_pending_with_no_migrations_applied_runs_all() {
+    async fn test_fresh_run_all_migrations_run_once_then_skip() {
         let tmp = TempDir::new().unwrap();
-
-        let report = run_migrations(
-            tmp.path(),
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let make = |log: &Arc<Mutex<Vec<String>>>| {
             vec![
-                Box::new(AlwaysApplies { name: "m001_a" }),
-                Box::new(AlwaysApplies { name: "m002_b" }),
-            ],
+                scripted("m001_a", Behavior::DidWork, log),
+                scripted("m002_b", Behavior::NoOp, log),
+                scripted("m003_c", Behavior::DidWork, log),
+            ]
+        };
+
+        let report = run_with_registry(tmp.path(), make(&log)).await.unwrap();
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["m001_a", "m002_b", "m003_c"],
+            "all migrations must be invoked, in order"
+        );
+        assert_eq!(report.ran, vec!["m001_a", "m003_c"]);
+        assert_eq!(
+            report.ran_no_op,
+            vec!["m002_b"],
+            "a no-op run is still processed"
+        );
+        assert!(report.skipped.is_empty());
+        assert!(report.seeded.is_empty());
+
+        // Every migration recorded success — including the no-op.
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|(_, status, _)| status == "success"));
+
+        // Second run: nothing is invoked; everything skips via the table.
+        let report2 = run_with_registry(tmp.path(), make(&log)).await.unwrap();
+        assert_eq!(
+            log.lock().unwrap().len(),
+            3,
+            "second run must not invoke any migration"
+        );
+        assert_eq!(report2.skipped, vec!["m001_a", "m002_b", "m003_c"]);
+        assert!(report2.ran.is_empty());
+        assert!(report2.ran_no_op.is_empty());
+    }
+
+    // ── Backfill from legacy migrations.json ──────────────────────────────────
+
+    #[tokio::test]
+    async fn test_backfill_seeds_legacy_applied_and_runs_the_rest() {
+        let tmp = TempDir::new().unwrap();
+        write_legacy_state(tmp.path(), &["m001_a", "m002_b"]);
+
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let registry = vec![
+            scripted("m001_a", Behavior::DidWork, &log),
+            scripted("m002_b", Behavior::DidWork, &log),
+            scripted("m003_c", Behavior::DidWork, &log),
+        ];
+
+        let report = run_with_registry(tmp.path(), registry).await.unwrap();
+        assert_eq!(
+            report.seeded,
+            vec!["m001_a", "m002_b"],
+            "legacy-applied migrations must be seeded, not run"
+        );
+        assert_eq!(report.ran, vec!["m003_c"]);
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["m003_c"],
+            "seeded migrations must not be invoked"
+        );
+
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|(_, status, _)| status == "success"));
+    }
+
+    #[tokio::test]
+    async fn test_backfill_happens_only_once() {
+        let tmp = TempDir::new().unwrap();
+        // First run with no legacy file creates the tracking table.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        run_with_registry(
+            tmp.path(),
+            vec![scripted("m001_a", Behavior::DidWork, &log)],
         )
         .await
         .unwrap();
 
-        assert_eq!(report.newly_applied, vec!["m001_a", "m002_b"]);
-        assert!(report.already_applied.is_empty());
-        assert!(report.skipped_not_needed.is_empty());
-    }
-
-    // ── Runner: already-applied entries are skipped ───────────────────────────
-
-    #[tokio::test]
-    async fn test_run_pending_skips_already_applied() {
-        let tmp = TempDir::new().unwrap();
-
-        // Pre-populate the state file with m001 already applied.
-        let mut pre = HashSet::new();
-        pre.insert("m001_a".to_string());
-        write_state(tmp.path(), &pre).await.unwrap();
-
-        let report = run_migrations(
+        // A legacy file appearing *after* the table exists must be ignored —
+        // the table is the sole source of truth from then on.
+        write_legacy_state(tmp.path(), &["m002_b"]);
+        let report = run_with_registry(
             tmp.path(),
             vec![
-                Box::new(AlwaysApplies { name: "m001_a" }), // already applied
-                Box::new(AlwaysApplies { name: "m002_b" }), // new
+                scripted("m001_a", Behavior::DidWork, &log),
+                scripted("m002_b", Behavior::DidWork, &log),
             ],
         )
         .await
         .unwrap();
-
-        assert_eq!(report.already_applied, vec!["m001_a"]);
-        assert_eq!(report.newly_applied, vec!["m002_b"]);
-        assert!(report.skipped_not_needed.is_empty());
+        assert!(
+            report.seeded.is_empty(),
+            "no re-seeding once the tracking table exists"
+        );
+        assert_eq!(report.ran, vec!["m002_b"], "m002_b must actually run");
     }
 
-    // ── Runner: not-needed migrations go into skipped_not_needed ─────────────
-
     #[tokio::test]
-    async fn test_run_pending_not_needed_goes_to_skipped() {
+    async fn test_backfill_ignores_legacy_names_not_in_registry() {
         let tmp = TempDir::new().unwrap();
+        write_legacy_state(tmp.path(), &["m001_a", "m999_retired"]);
 
-        let report = run_migrations(
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let report = run_with_registry(
             tmp.path(),
-            vec![Box::new(NeverNeeded { name: "m001_noop" })],
+            vec![scripted("m001_a", Behavior::DidWork, &log)],
         )
         .await
         .unwrap();
-
-        assert!(report.newly_applied.is_empty());
-        assert!(report.already_applied.is_empty());
-        assert_eq!(report.skipped_not_needed, vec!["m001_noop"]);
-
-        // A not-needed migration should NOT be written to the state file.
-        let state = read_state(tmp.path()).await.unwrap();
-        assert!(
-            !state.contains("m001_noop"),
-            "not-needed migration must not appear in state file"
-        );
+        assert_eq!(report.seeded, vec!["m001_a"]);
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 1, "unknown legacy names are not seeded");
     }
 
-    // ── Runner: stops at first failure ────────────────────────────────────────
+    // ── Deleted row re-runs ────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn test_run_pending_stops_at_first_failure() {
+    async fn test_deleted_success_row_reruns_that_migration() {
         let tmp = TempDir::new().unwrap();
-
-        let result = run_migrations(
-            tmp.path(),
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let make = |log: &Arc<Mutex<Vec<String>>>| {
             vec![
-                Box::new(AlwaysApplies { name: "m001_ok" }),
-                Box::new(AlwaysFails { name: "m002_fail" }),
-                Box::new(AlwaysApplies { name: "m003_ok" }), // must not run
-            ],
-        )
-        .await;
+                scripted("m001_a", Behavior::DidWork, log),
+                scripted("m002_b", Behavior::NoOp, log),
+            ]
+        };
 
-        assert!(result.is_err(), "runner should propagate the error");
+        run_with_registry(tmp.path(), make(&log)).await.unwrap();
+        delete_row(tmp.path(), "m002_b");
 
-        // m001 applied before the failure — must be in state.
-        let state = read_state(tmp.path()).await.unwrap();
-        assert!(
-            state.contains("m001_ok"),
-            "m001 was applied before the error"
+        let report = run_with_registry(tmp.path(), make(&log)).await.unwrap();
+        assert_eq!(report.skipped, vec!["m001_a"]);
+        assert_eq!(
+            report.ran_no_op,
+            vec!["m002_b"],
+            "the migration with the deleted row must re-run"
         );
-        assert!(
-            !state.contains("m003_ok"),
-            "m003 must not be in state (never ran)"
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["m001_a", "m002_b", "m002_b"],
+            "m002_b invoked twice in total, m001_a once"
         );
+        // Row recorded success again.
+        let rows = tracking_rows(tmp.path());
+        assert!(rows.iter().all(|(_, status, _)| status == "success"));
     }
 
-    // ── Runner: idempotent — calling twice has same result the second time ────
+    // ── Failure handling ───────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn test_run_pending_idempotent() {
+    async fn test_failure_records_error_aborts_and_blocks_later_migrations() {
         let tmp = TempDir::new().unwrap();
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let failing = Arc::new(AtomicBool::new(true));
+        let make = |log: &Arc<Mutex<Vec<String>>>, flag: &Arc<AtomicBool>| {
+            vec![
+                scripted("m001_ok", Behavior::DidWork, log),
+                scripted("m002_fail", Behavior::FailWhile(Arc::clone(flag)), log),
+                scripted("m003_never", Behavior::DidWork, log),
+            ]
+        };
 
-        // First call
-        let r1 = run_migrations(tmp.path(), vec![Box::new(AlwaysApplies { name: "m001_a" })])
+        // First startup: m001 succeeds, m002 fails and aborts, m003 never runs.
+        let err = run_with_registry(tmp.path(), make(&log, &failing))
             .await
-            .unwrap();
-        assert_eq!(r1.newly_applied, vec!["m001_a"]);
+            .expect_err("must abort on failure");
+        let msg = err.to_string();
+        assert!(msg.contains("m002_fail"), "error must name the migration");
+        assert!(
+            msg.contains("simulated migration failure"),
+            "error must include the cause"
+        );
+        assert!(
+            msg.contains("DELETE FROM schema_migrations"),
+            "error must describe the recovery workflow"
+        );
+        assert_eq!(*log.lock().unwrap(), vec!["m001_ok", "m002_fail"]);
 
-        // Second call with the same migration list — it is now in the applied set.
-        let r2 = run_migrations(tmp.path(), vec![Box::new(AlwaysApplies { name: "m001_a" })])
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 2, "m003_never must have no row");
+        let failed = rows.iter().find(|(n, _, _)| n == "m002_fail").unwrap();
+        assert_eq!(failed.1, "failed");
+        assert!(
+            failed
+                .2
+                .as_deref()
+                .unwrap_or_default()
+                .contains("simulated migration failure"),
+            "failed row must carry the error text"
+        );
+
+        // Second startup: the failed row blocks startup without invoking
+        // anything at all.
+        let err2 = run_with_registry(tmp.path(), make(&log, &failing))
             .await
-            .unwrap();
-        assert_eq!(r2.already_applied, vec!["m001_a"]);
-        assert!(r2.newly_applied.is_empty());
+            .expect_err("failed row must block startup");
+        assert!(err2.to_string().contains("m002_fail"));
+        assert!(err2.to_string().contains("previously failed"));
+        assert_eq!(
+            log.lock().unwrap().len(),
+            2,
+            "no migration may be invoked while a failed row blocks startup"
+        );
+
+        // Recovery: fix the issue (flip the flag), delete the failed row —
+        // the migration re-runs and the rest of the chain completes.
+        failing.store(false, Ordering::SeqCst);
+        delete_row(tmp.path(), "m002_fail");
+        let report = run_with_registry(tmp.path(), make(&log, &failing))
+            .await
+            .expect("must succeed after recovery");
+        assert_eq!(report.skipped, vec!["m001_ok"]);
+        assert_eq!(report.ran, vec!["m002_fail", "m003_never"]);
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|(_, status, _)| status == "success"));
     }
 
-    // ── Atomic write — no .tmp file left behind ───────────────────────────────
+    // ── Ordering ───────────────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn test_run_pending_atomic_write_no_tmp_leftover() {
+    async fn test_registry_order_is_execution_order() {
         let tmp = TempDir::new().unwrap();
-
-        run_migrations(tmp.path(), vec![Box::new(AlwaysApplies { name: "m001_a" })])
-            .await
-            .unwrap();
-
-        let tmp_file = tmp.path().join("migrations.json.tmp");
-        assert!(
-            !tmp_file.exists(),
-            "migrations.json.tmp must not exist after successful write"
-        );
-
-        // The real state file must exist and be valid.
-        assert!(
-            tmp.path().join("migrations.json").exists(),
-            "migrations.json must exist"
-        );
+        let log = Arc::new(Mutex::new(Vec::new()));
+        // Names deliberately not in lexicographic order — the runner must
+        // follow registry order, not name order.
+        let registry = vec![
+            scripted("m_zulu", Behavior::DidWork, &log),
+            scripted("m_alpha", Behavior::DidWork, &log),
+            scripted("m_mike", Behavior::DidWork, &log),
+        ];
+        run_with_registry(tmp.path(), registry).await.unwrap();
+        assert_eq!(*log.lock().unwrap(), vec!["m_zulu", "m_alpha", "m_mike"]);
     }
 
-    // ── Real registry smoke test: run_pending with real data dir ─────────────
+    // ── Real registry ──────────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn test_run_pending_real_registry_fresh_install() {
-        // Fresh install: no jobs.json, no workflows.json, no acs.db.
-        // m001 has nothing to do; m002 creates the empty SQLite DB.
+        // Fresh install: every registered migration is invoked once and
+        // recorded success; acs.db ends up with the full schema.
         let tmp = TempDir::new().unwrap();
         let report = run_pending(tmp.path()).await.unwrap();
 
-        assert!(report.already_applied.is_empty());
-        assert!(report
-            .skipped_not_needed
-            .contains(&"m001_jobs_to_workflows".to_string()));
-        assert!(report
-            .newly_applied
-            .contains(&"m002_json_to_sqlite".to_string()));
+        assert!(report.seeded.is_empty());
+        assert!(report.skipped.is_empty());
+        let processed = report.ran.len() + report.ran_no_op.len();
+        assert_eq!(
+            processed, 8,
+            "all 8 registered migrations must be processed"
+        );
+        assert!(
+            report.ran.contains(&"m002_json_to_sqlite".to_string()),
+            "m002 creates the database schema on a fresh install"
+        );
         assert!(
             tmp.path().join("acs.db").exists(),
-            "m002 must have created acs.db on a fresh install"
+            "acs.db must exist after a fresh-install run"
         );
+
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 8);
+        assert!(
+            rows.iter().all(|(_, status, _)| status == "success"),
+            "a fresh install must end with all migrations recorded as success"
+        );
+
+        // Second startup: everything skips; nothing new is recorded.
+        let report2 = run_pending(tmp.path()).await.unwrap();
+        assert_eq!(report2.skipped.len(), 8);
+        assert!(report2.ran.is_empty());
+        assert!(report2.ran_no_op.is_empty());
+    }
+
+    /// Build a data dir that simulates an install from before the tracking
+    /// table existed: an old-shape acs.db (inline UNIQUE on workflows.name,
+    /// no `deleted` column) plus a migrations.json listing everything up to
+    /// and including m007 as applied.
+    fn build_legacy_data_dir(data_dir: &Path) {
+        let conn = Connection::open(data_dir.join("acs.db")).expect("create legacy acs.db");
+        conn.execute_batch(
+            "CREATE TABLE workflows (
+                 id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+                 version INTEGER NOT NULL, schedule TEXT NOT NULL,
+                 timezone TEXT, schedule_mode TEXT NOT NULL,
+                 enabled INTEGER NOT NULL, steps_json TEXT NOT NULL,
+                 default_input TEXT, working_dir TEXT, env_vars TEXT,
+                 allow_concurrent INTEGER NOT NULL, on_failure TEXT NOT NULL,
+                 last_run_at TEXT, last_run_status TEXT, last_run_id TEXT,
+                 created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+                 is_favorited INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE workflow_runs (
+                 run_id TEXT PRIMARY KEY, workflow_id TEXT NOT NULL,
+                 workflow_version INTEGER NOT NULL, workflow_snapshot TEXT NOT NULL,
+                 started_at TEXT NOT NULL, finished_at TEXT,
+                 status TEXT NOT NULL, trigger_input TEXT,
+                 steps_json TEXT NOT NULL, total_cost_usd REAL,
+                 total_duration_ms INTEGER,
+                 total_input_tokens INTEGER NOT NULL DEFAULT 0,
+                 total_output_tokens INTEGER NOT NULL DEFAULT 0,
+                 FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+             );
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO workflows (id, name, version, schedule, schedule_mode,
+                 enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at)
+             VALUES ('id-1', 'legacy-wf', 1, '* * * * *', 'cron', 1, '[]', 1, 'abort',
+                 '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z');",
+        )
+        .expect("apply legacy schema");
+        write_legacy_state(
+            data_dir,
+            &[
+                "m001_jobs_to_workflows",
+                "m002_json_to_sqlite",
+                "m003_drop_step_output_summary",
+                "m004_drop_input_schema",
+                "m005_shell_claude_to_agent",
+                "m006_agent_step_normalize",
+                "m007_add_token_columns",
+            ],
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_pending_real_registry_legacy_backfill() {
+        let tmp = TempDir::new().unwrap();
+        build_legacy_data_dir(tmp.path());
+
+        let report = run_pending(tmp.path()).await.unwrap();
+        assert_eq!(
+            report.seeded.len(),
+            7,
+            "m001..m007 must be seeded from migrations.json"
+        );
+        assert_eq!(
+            report.ran,
+            vec!["m008_add_workflow_deleted"],
+            "only the migration missing from the legacy state runs"
+        );
+
+        // m008 really executed: the inline UNIQUE is gone and the data survived.
+        let conn = Connection::open(tmp.path().join("acs.db")).expect("open");
+        let ddl: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'workflows'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read DDL");
+        assert!(
+            !ddl.to_uppercase().contains("UNIQUE"),
+            "m008 must have rebuilt the workflows table"
+        );
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM workflows", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(n, 1, "legacy workflow row must survive");
+        drop(conn);
+
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 8);
+        assert!(rows.iter().all(|(_, status, _)| status == "success"));
+
+        // Deleting a success row re-runs that migration on the next startup;
+        // its internal idempotency makes the re-run a safe no-op.
+        delete_row(tmp.path(), "m008_add_workflow_deleted");
+        let report2 = run_pending(tmp.path()).await.unwrap();
+        assert_eq!(report2.skipped.len(), 7);
+        assert_eq!(report2.ran_no_op, vec!["m008_add_workflow_deleted"]);
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 8);
+        assert!(rows.iter().all(|(_, status, _)| status == "success"));
+    }
+
+    /// A legacy database whose migrations.json was lost entirely: every
+    /// migration runs, each no-ops via its internal idempotency, and all are
+    /// recorded success.
+    #[tokio::test]
+    async fn test_run_pending_real_registry_legacy_without_state_file() {
+        let tmp = TempDir::new().unwrap();
+        build_legacy_data_dir(tmp.path());
+        std::fs::remove_file(tmp.path().join("migrations.json")).expect("remove state file");
+
+        let report = run_pending(tmp.path()).await.unwrap();
+        assert!(report.seeded.is_empty(), "nothing to seed without the file");
+        assert!(report.skipped.is_empty());
+        assert_eq!(report.ran.len() + report.ran_no_op.len(), 8);
+
+        let rows = tracking_rows(tmp.path());
+        assert_eq!(rows.len(), 8);
+        assert!(rows.iter().all(|(_, status, _)| status == "success"));
+
+        // The data survived the full pass.
+        let conn = Connection::open(tmp.path().join("acs.db")).expect("open");
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM workflows", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(n, 1, "legacy workflow row must survive a full re-run");
     }
 }

--- a/acs/src/migration/mod.rs
+++ b/acs/src/migration/mod.rs
@@ -33,6 +33,7 @@ mod m004_drop_input_schema;
 mod m005_shell_claude_to_agent;
 mod m006_agent_step_normalize;
 mod m007_add_token_columns;
+mod m008_add_workflow_deleted;
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -77,6 +78,7 @@ fn registry() -> Vec<Box<dyn Migration>> {
         Box::new(m005_shell_claude_to_agent::ShellClaudeToAgent),
         Box::new(m006_agent_step_normalize::AgentStepNormalize),
         Box::new(m007_add_token_columns::AddTokenColumns),
+        Box::new(m008_add_workflow_deleted::AddWorkflowDeleted),
     ]
 }
 

--- a/acs/src/migration/mod.rs
+++ b/acs/src/migration/mod.rs
@@ -51,8 +51,9 @@
 //! already applied without being invoked. Every other migration then runs
 //! normally; on an already-migrated database their internal idempotency makes
 //! that a safe no-op, which is recorded as `success`. After this one-time
-//! backfill the table is the sole source of truth; `migrations.json` is left
-//! on disk but never written again.
+//! backfill the table is the sole source of truth and the legacy file is
+//! deleted (best-effort; a removal failure is only logged). A corrupt legacy
+//! file seeds nothing and is left in place for inspection.
 //!
 //! # Adding a new migration
 //!
@@ -286,8 +287,7 @@ async fn run_with_registry(
     with_tracking_db(&db_path, |_| Ok(())).await?;
 
     if !had_tracking_table {
-        let legacy_applied = read_legacy_state(data_dir).await?;
-        if !legacy_applied.is_empty() {
+        if let Some(legacy_applied) = read_legacy_state(data_dir).await? {
             let seed: Vec<String> = migrations
                 .iter()
                 .map(|m| m.name().to_string())
@@ -296,6 +296,27 @@ async fn run_with_registry(
             if !seed.is_empty() {
                 seed_success_rows(&db_path, seed.clone()).await?;
                 report.seeded = seed;
+            }
+            // The legacy state file has been fully consumed by the backfill —
+            // retire it. Best-effort: a removal failure is only logged; the
+            // tracking table already holds the authoritative state.
+            let legacy_path = data_dir.join("migrations.json");
+            match tokio::fs::remove_file(&legacy_path).await {
+                Ok(()) => {
+                    tracing::info!(
+                        "Removed legacy migration state file {} after backfilling \
+                         schema_migrations",
+                        legacy_path.display()
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Backfill complete but failed to remove legacy {}: {}. \
+                         Manual cleanup recommended.",
+                        legacy_path.display(),
+                        e
+                    );
+                }
             }
         }
     }
@@ -370,17 +391,20 @@ struct LegacyMigrationState {
 
 /// Read the applied-migration names from the legacy `<data_dir>/migrations.json`.
 /// Used only to backfill the `schema_migrations` table the first time the
-/// tracked runner sees a data dir; the file is never written again.
+/// tracked runner sees a data dir; on a successful read the caller deletes
+/// the file afterwards.
 ///
-/// - If the file does not exist, returns an empty set (fresh install).
-/// - If the file is corrupt (invalid JSON), logs a warning and returns an
-///   empty set — every migration then runs normally, and their internal
-///   idempotency keeps that safe on an already-migrated database.
-async fn read_legacy_state(data_dir: &Path) -> Result<HashSet<String>, AcsError> {
+/// Returns `Ok(Some(names))` when the file was parsed successfully (the
+/// caller then also retires the file), and `Ok(None)` when there is nothing
+/// usable: the file is missing, unreadable, or corrupt. Unreadable/corrupt
+/// files are logged and **left in place** for inspection; every migration
+/// then runs normally, and their internal idempotency keeps that safe on an
+/// already-migrated database.
+async fn read_legacy_state(data_dir: &Path) -> Result<Option<HashSet<String>>, AcsError> {
     let path = data_dir.join("migrations.json");
 
     if !path.exists() {
-        return Ok(HashSet::new());
+        return Ok(None);
     }
 
     match tokio::fs::read_to_string(&path).await {
@@ -390,17 +414,17 @@ async fn read_legacy_state(data_dir: &Path) -> Result<HashSet<String>, AcsError>
                 path.display(),
                 e
             );
-            Ok(HashSet::new())
+            Ok(None)
         }
         Ok(content) => match serde_json::from_str::<LegacyMigrationState>(&content) {
-            Ok(state) => Ok(state.applied.into_iter().collect()),
+            Ok(state) => Ok(Some(state.applied.into_iter().collect())),
             Err(e) => {
                 tracing::warn!(
                     "migrations.json is corrupt ({}): {}. Treating as empty.",
                     path.display(),
                     e
                 );
-                Ok(HashSet::new())
+                Ok(None)
             }
         },
     }
@@ -498,22 +522,46 @@ mod tests {
     // ── Legacy state file reading ──────────────────────────────────────────────
 
     #[tokio::test]
-    async fn test_legacy_state_read_empty_when_no_file() {
+    async fn test_legacy_state_read_none_when_no_file() {
         let tmp = TempDir::new().unwrap();
         let state = read_legacy_state(tmp.path()).await.unwrap();
-        assert!(state.is_empty());
+        assert!(state.is_none());
     }
 
     #[tokio::test]
-    async fn test_legacy_state_corruption_treated_as_empty() {
+    async fn test_legacy_state_corruption_treated_as_unusable() {
         let tmp = TempDir::new().unwrap();
         tokio::fs::write(tmp.path().join("migrations.json"), b"not valid json {{{{")
             .await
             .unwrap();
         let state = read_legacy_state(tmp.path()).await.unwrap();
         assert!(
-            state.is_empty(),
-            "corrupt state file should be treated as empty"
+            state.is_none(),
+            "corrupt state file should be treated as unusable"
+        );
+    }
+
+    /// A corrupt legacy file seeds nothing, is left in place for inspection,
+    /// and every migration runs normally.
+    #[tokio::test]
+    async fn test_corrupt_legacy_file_left_in_place_and_all_migrations_run() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(tmp.path().join("migrations.json"), b"not valid json {{{{")
+            .await
+            .unwrap();
+
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let report = run_with_registry(
+            tmp.path(),
+            vec![scripted("m001_a", Behavior::DidWork, &log)],
+        )
+        .await
+        .unwrap();
+        assert!(report.seeded.is_empty());
+        assert_eq!(report.ran, vec!["m001_a"]);
+        assert!(
+            tmp.path().join("migrations.json").exists(),
+            "corrupt legacy file must be left in place for inspection"
         );
     }
 
@@ -593,6 +641,27 @@ mod tests {
         let rows = tracking_rows(tmp.path());
         assert_eq!(rows.len(), 3);
         assert!(rows.iter().all(|(_, status, _)| status == "success"));
+
+        // The legacy file is retired after a successful backfill.
+        assert!(
+            !tmp.path().join("migrations.json").exists(),
+            "migrations.json must be deleted after the backfill"
+        );
+
+        // A second pass works fine without it: everything skips via the table.
+        let log2 = Arc::new(Mutex::new(Vec::new()));
+        let report2 = run_with_registry(
+            tmp.path(),
+            vec![
+                scripted("m001_a", Behavior::DidWork, &log2),
+                scripted("m002_b", Behavior::DidWork, &log2),
+                scripted("m003_c", Behavior::DidWork, &log2),
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(report2.skipped, vec!["m001_a", "m002_b", "m003_c"]);
+        assert!(log2.lock().unwrap().is_empty(), "nothing re-runs");
     }
 
     #[tokio::test]
@@ -624,6 +693,10 @@ mod tests {
             "no re-seeding once the tracking table exists"
         );
         assert_eq!(report.ran, vec!["m002_b"], "m002_b must actually run");
+        assert!(
+            tmp.path().join("migrations.json").exists(),
+            "a legacy file appearing after the table exists is not consumed"
+        );
     }
 
     #[tokio::test]
@@ -868,6 +941,10 @@ mod tests {
             report.ran,
             vec!["m008_add_workflow_deleted"],
             "only the migration missing from the legacy state runs"
+        );
+        assert!(
+            !tmp.path().join("migrations.json").exists(),
+            "the legacy state file must be deleted after the backfill"
         );
 
         // m008 really executed: the inline UNIQUE is gone and the data survived.

--- a/acs/src/models/workflow.rs
+++ b/acs/src/models/workflow.rs
@@ -91,6 +91,11 @@ pub fn avg_cost_per_run(total_usd: f64, runs: u64) -> f64 {
 pub struct WorkflowCostEntry {
     pub workflow_id: Uuid,
     pub workflow_name: String,
+    /// `true` when the parent workflow has been soft-deleted (ACS-25, v4.2.14).
+    /// Cost/token history is aggregated from the persisted `workflow_runs`
+    /// rows, so it is still returned here even after the workflow is deleted.
+    #[serde(default)]
+    pub workflow_deleted: bool,
     pub cost_summary: CostSummary,
 }
 
@@ -107,6 +112,10 @@ pub struct CostWorkflowsListResponse {
 pub struct CostWorkflowResponse {
     pub workflow_id: Uuid,
     pub workflow_name: String,
+    /// `true` when the workflow has been soft-deleted (ACS-25, v4.2.14). The
+    /// per-id cost endpoint still returns 200 with the persisted cost history.
+    #[serde(default)]
+    pub workflow_deleted: bool,
     pub cost_summary: CostSummary,
 }
 
@@ -141,6 +150,12 @@ pub struct Workflow {
     /// (or via PATCH). Does NOT bump `version` when changed.
     #[serde(default)]
     pub is_favorited: bool,
+    /// Soft-delete flag (ACS-25, v4.2.14). When `true` the workflow is hidden
+    /// from list / name-resolution / scheduling / triggering and behaves as
+    /// "not found" for the normal workflow endpoints, but its row and all of
+    /// its `workflow_runs` persist so cost/token history survives deletion.
+    #[serde(default)]
+    pub deleted: bool,
     pub steps: Vec<StepDef>,
     #[serde(default)]
     pub default_input: Option<serde_json::Value>,
@@ -174,6 +189,7 @@ impl PartialEq for Workflow {
             && self.schedule_mode == other.schedule_mode
             && self.enabled == other.enabled
             && self.is_favorited == other.is_favorited
+            && self.deleted == other.deleted
             && self.steps == other.steps
             && self.default_input == other.default_input
             && self.working_dir == other.working_dir
@@ -640,6 +656,7 @@ mod tests {
             schedule_mode: ScheduleMode::default(),
             enabled: true,
             is_favorited: false,
+            deleted: false,
             steps: vec![make_shell_step("step-1")],
             default_input: None,
             working_dir: Some("/tmp".to_string()),

--- a/acs/src/models/workflow.rs
+++ b/acs/src/models/workflow.rs
@@ -91,7 +91,7 @@ pub fn avg_cost_per_run(total_usd: f64, runs: u64) -> f64 {
 pub struct WorkflowCostEntry {
     pub workflow_id: Uuid,
     pub workflow_name: String,
-    /// `true` when the parent workflow has been soft-deleted (ACS-25, v4.2.14).
+    /// `true` when the parent workflow has been soft-deleted.
     /// Cost/token history is aggregated from the persisted `workflow_runs`
     /// rows, so it is still returned here even after the workflow is deleted.
     #[serde(default)]
@@ -112,7 +112,7 @@ pub struct CostWorkflowsListResponse {
 pub struct CostWorkflowResponse {
     pub workflow_id: Uuid,
     pub workflow_name: String,
-    /// `true` when the workflow has been soft-deleted (ACS-25, v4.2.14). The
+    /// `true` when the workflow has been soft-deleted. The
     /// per-id cost endpoint still returns 200 with the persisted cost history.
     #[serde(default)]
     pub workflow_deleted: bool,
@@ -150,7 +150,7 @@ pub struct Workflow {
     /// (or via PATCH). Does NOT bump `version` when changed.
     #[serde(default)]
     pub is_favorited: bool,
-    /// Soft-delete flag (ACS-25, v4.2.14). When `true` the workflow is hidden
+    /// Soft-delete flag. When `true` the workflow is hidden
     /// from list / name-resolution / scheduling / triggering and behaves as
     /// "not found" for the normal workflow endpoints, but its row and all of
     /// its `workflow_runs` persist so cost/token history survives deletion.

--- a/acs/src/server/workflow_routes.rs
+++ b/acs/src/server/workflow_routes.rs
@@ -123,6 +123,26 @@ fn map_store_error(e: anyhow::Error) -> (StatusCode, Json<ErrorResponse>) {
                     message: msg.clone(),
                 }),
             ),
+            // A database constraint / foreign-key violation is a conflict with
+            // existing data, not an unexpected internal fault — surface it as a
+            // structured 409 instead of a bare 500 (ACS-25 §6).
+            AcsError::Storage(msg)
+                if {
+                    let lower = msg.to_lowercase();
+                    lower.contains("foreign key") || lower.contains("constraint")
+                } =>
+            {
+                (
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        error: "constraint_violation".to_string(),
+                        message: format!(
+                            "The operation conflicts with a database constraint: {}",
+                            msg
+                        ),
+                    }),
+                )
+            }
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
@@ -391,6 +411,26 @@ struct DefaultWorkingDirError {
     io_err: std::io::Error,
 }
 
+/// Derive the ACS-managed default working directory for a workflow name:
+/// `<root>/<sanitized-name>`, where `<root>` is `config.display_workflow_dir_root`
+/// when set, otherwise `<documents>/agent-cron-scheduler`. Returns `None` only
+/// when neither a configured root nor the user Documents dir can be resolved.
+///
+/// This is the single source of truth for "is this working_dir one we created
+/// and therefore safe to delete on soft-delete". It is used both when filling
+/// in the default on create and when deciding whether to remove the operating
+/// folder on delete (ACS-25).
+fn derive_default_working_dir(
+    config: &crate::models::DaemonConfig,
+    name: &str,
+) -> Option<std::path::PathBuf> {
+    let root: Option<std::path::PathBuf> = match config.display_workflow_dir_root.as_deref() {
+        Some(p) => Some(p.to_path_buf()),
+        None => dirs::document_dir().map(|d| d.join("agent-cron-scheduler")),
+    };
+    root.map(|r| r.join(sanitize_workflow_name(name)))
+}
+
 /// Fill in daemon-config-driven defaults on a freshly-deserialised
 /// `NewWorkflow` body. Called from `create_workflow` before the body reaches
 /// the store.
@@ -412,27 +452,18 @@ fn apply_new_workflow_defaults(
     }
 
     if body.working_dir.is_none() {
-        let root: Option<std::path::PathBuf> = match config.display_workflow_dir_root.as_deref() {
-            Some(p) => Some(p.to_path_buf()),
-            None => dirs::document_dir().map(|d| d.join("agent-cron-scheduler")),
-        };
-
-        match root {
-            Some(root_path) => {
-                let sanitized = sanitize_workflow_name(&body.name);
-                let target = root_path.join(&sanitized);
-                match std::fs::create_dir_all(&target) {
-                    Ok(()) => {
-                        body.working_dir = Some(target.to_string_lossy().into_owned());
-                    }
-                    Err(e) => {
-                        return Err(DefaultWorkingDirError {
-                            path: target,
-                            io_err: e,
-                        });
-                    }
+        match derive_default_working_dir(config, &body.name) {
+            Some(target) => match std::fs::create_dir_all(&target) {
+                Ok(()) => {
+                    body.working_dir = Some(target.to_string_lossy().into_owned());
                 }
-            }
+                Err(e) => {
+                    return Err(DefaultWorkingDirError {
+                        path: target,
+                        io_err: e,
+                    });
+                }
+            },
             None => {
                 tracing::warn!(
                     workflow_name = %body.name,
@@ -582,7 +613,13 @@ pub async fn list_workflow_costs(
         Err((status, body)) => return (status, body).into_response(),
     };
 
-    let workflows = match state.workflow_store.list_workflows().await {
+    // Include soft-deleted workflows so their persisted cost/token history
+    // remains visible (flagged via `workflow_deleted`) — ACS-25 §5.
+    let workflows = match state
+        .workflow_store
+        .list_workflows_including_deleted()
+        .await
+    {
         Ok(w) => w,
         Err(e) => {
             tracing::error!("Failed to list workflows for cost: {}", e);
@@ -634,6 +671,7 @@ pub async fn list_workflow_costs(
         entries.push(WorkflowCostEntry {
             workflow_id: wf.id,
             workflow_name: wf.name.clone(),
+            workflow_deleted: wf.deleted,
             cost_summary,
         });
     }
@@ -713,7 +751,13 @@ pub async fn get_workflow_costs(
         Err((status, body)) => return (status, body).into_response(),
     };
 
-    let workflow = match state.workflow_store.get_workflow(workflow_id).await {
+    // Include soft-deleted workflows: their cost history persists and this
+    // endpoint returns 200 with `workflow_deleted: true` (ACS-25 §5).
+    let workflow = match state
+        .workflow_store
+        .get_workflow_including_deleted(workflow_id)
+        .await
+    {
         Ok(Some(wf)) => wf,
         Ok(None) => {
             return error_response(
@@ -762,6 +806,7 @@ pub async fn get_workflow_costs(
             serde_json::to_value(CostWorkflowResponse {
                 workflow_id,
                 workflow_name: workflow.name,
+                workflow_deleted: workflow.deleted,
                 cost_summary,
             })
             .unwrap(),
@@ -893,9 +938,47 @@ pub async fn delete_workflow(
     let version = wf.version;
     let workflow_name = wf.name.clone();
 
+    // Active-run guard (ACS-25 §2): refuse to soft-delete a workflow that still
+    // has a run in progress. `list_runs(id, 0, 0)` returns all runs (limit 0 ==
+    // no limit).
+    match state.workflow_run_store.list_runs(workflow_id, 0, 0).await {
+        Ok(runs) => {
+            if let Some(active) = runs.iter().find(|r| r.status == RunStatus::Running) {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        error: "workflow_run_active".to_string(),
+                        message: format!(
+                            "Cannot delete workflow '{}' while run {} is still running. \
+                             Kill the run or wait for it to finish, then retry.",
+                            workflow_name, active.run_id
+                        ),
+                    }),
+                )
+                    .into_response();
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                workflow_id = %workflow_id,
+                "Failed to list runs for delete active-run guard: {}",
+                e
+            );
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                &format!("Failed to check active runs: {}", e),
+            )
+            .into_response();
+        }
+    }
+
     match state.workflow_store.delete_workflow(workflow_id).await {
         Ok(()) => {
-            // Evict cache entry for the deleted workflow.
+            // Best-effort on-disk cleanup AFTER the DB update succeeds. Never
+            // fails the request (ACS-25 §2).
+            cleanup_workflow_artifacts(&state, &wf).await;
+            // Evict cache entry; cost data recomputes from the persisted runs.
             state.cost_cache.forget(workflow_id).await;
             // Broadcast WorkflowChanged{Deleted}
             let _ = state
@@ -905,12 +988,59 @@ pub async fn delete_workflow(
                     version,
                     change_kind: WorkflowChangeKind::Deleted,
                 });
-            tracing::info!(workflow_id = %workflow_id, name = %workflow_name, "workflow deleted");
+            tracing::info!(workflow_id = %workflow_id, name = %workflow_name, "workflow soft-deleted");
             StatusCode::NO_CONTENT.into_response()
         }
         Err(e) => {
             let (status, body) = map_store_error(e);
             (status, body).into_response()
+        }
+    }
+}
+
+/// Best-effort removal of on-disk artifacts for a soft-deleted workflow.
+/// Every failure is logged as a warning and swallowed — cleanup must never
+/// fail the delete request (ACS-25 §2).
+///
+///   a) the run-log directory `<data_dir>/logs/<workflow_id>/`
+///   b) the operating folder — **only** when the stored `working_dir` equals
+///      the ACS-managed default path we would derive for this workflow. A
+///      custom, user-specified `working_dir` is NEVER touched.
+async fn cleanup_workflow_artifacts(state: &AppState, wf: &Workflow) {
+    let data_dir = resolve_data_dir_for(state);
+    let log_dir = data_dir.join("logs").join(wf.id.to_string());
+    if log_dir.exists() {
+        if let Err(e) = tokio::fs::remove_dir_all(&log_dir).await {
+            tracing::warn!(
+                workflow_id = %wf.id,
+                "failed to remove log dir {:?} on delete: {}",
+                log_dir, e
+            );
+        }
+    }
+
+    if let Some(ref working_dir) = wf.working_dir {
+        match derive_default_working_dir(&state.config, &wf.name) {
+            Some(default_dir) if std::path::Path::new(working_dir) == default_dir.as_path() => {
+                if default_dir.exists() {
+                    if let Err(e) = tokio::fs::remove_dir_all(&default_dir).await {
+                        tracing::warn!(
+                            workflow_id = %wf.id,
+                            "failed to remove operating folder {:?} on delete: {}",
+                            default_dir, e
+                        );
+                    }
+                }
+            }
+            _ => {
+                // Custom working_dir, or the name was changed since creation so
+                // it no longer matches the derived default — leave it untouched.
+                tracing::info!(
+                    workflow_id = %wf.id,
+                    working_dir = %working_dir,
+                    "leaving working_dir in place on delete (custom or non-default path)"
+                );
+            }
         }
     }
 }
@@ -1669,9 +1799,31 @@ mod tests {
     #[async_trait]
     impl WorkflowStore for InMemoryWorkflowStore {
         async fn list_workflows(&self) -> anyhow::Result<Vec<Workflow>> {
+            Ok(self
+                .workflows
+                .read()
+                .await
+                .iter()
+                .filter(|w| !w.deleted)
+                .cloned()
+                .collect())
+        }
+        async fn list_workflows_including_deleted(&self) -> anyhow::Result<Vec<Workflow>> {
             Ok(self.workflows.read().await.clone())
         }
         async fn get_workflow(&self, id: Uuid) -> anyhow::Result<Option<Workflow>> {
+            Ok(self
+                .workflows
+                .read()
+                .await
+                .iter()
+                .find(|w| w.id == id && !w.deleted)
+                .cloned())
+        }
+        async fn get_workflow_including_deleted(
+            &self,
+            id: Uuid,
+        ) -> anyhow::Result<Option<Workflow>> {
             Ok(self
                 .workflows
                 .read()
@@ -1686,14 +1838,14 @@ mod tests {
                 .read()
                 .await
                 .iter()
-                .find(|w| w.name == name)
+                .find(|w| w.name == name && !w.deleted)
                 .cloned())
         }
         async fn create_workflow(&self, new: NewWorkflow) -> anyhow::Result<Workflow> {
             // Mirror the real SqliteWorkflowStore: validate before persisting.
             crate::models::workflow::validate_new_workflow(&new)?;
             let mut wfs = self.workflows.write().await;
-            if wfs.iter().any(|w| w.name == new.name) {
+            if wfs.iter().any(|w| w.name == new.name && !w.deleted) {
                 return Err(crate::errors::AcsError::Conflict(format!(
                     "A workflow with name '{}' already exists",
                     new.name
@@ -1710,6 +1862,7 @@ mod tests {
                 schedule_mode: new.schedule_mode,
                 enabled: new.enabled,
                 is_favorited: false,
+                deleted: false,
                 steps: new.steps,
                 default_input: new.default_input,
                 working_dir: new.working_dir,
@@ -1734,10 +1887,13 @@ mod tests {
             let mut wfs = self.workflows.write().await;
             let idx = wfs
                 .iter()
-                .position(|w| w.id == id)
+                .position(|w| w.id == id && !w.deleted)
                 .ok_or_else(|| anyhow::anyhow!("not found"))?;
             if let Some(ref new_name) = update.name {
-                if wfs.iter().any(|w| w.name == *new_name && w.id != id) {
+                if wfs
+                    .iter()
+                    .any(|w| w.name == *new_name && w.id != id && !w.deleted)
+                {
                     return Err(crate::errors::AcsError::Conflict(format!(
                         "A workflow with name '{}' already exists",
                         new_name
@@ -1778,12 +1934,20 @@ mod tests {
             Ok(wf.clone())
         }
         async fn delete_workflow(&self, id: Uuid) -> anyhow::Result<()> {
+            // Soft delete (ACS-25): flag the row instead of removing it so its
+            // cost history persists and its name is freed for reuse.
             let mut wfs = self.workflows.write().await;
-            let len_before = wfs.len();
-            wfs.retain(|w| w.id != id);
-            if wfs.len() == len_before {
-                return Err(anyhow::anyhow!("not found"));
-            }
+            let wf = wfs
+                .iter_mut()
+                .find(|w| w.id == id && !w.deleted)
+                .ok_or_else(|| {
+                    crate::errors::AcsError::NotFound(format!(
+                        "Workflow with id '{}' not found",
+                        id
+                    ))
+                })?;
+            wf.deleted = true;
+            wf.updated_at = Utc::now();
             Ok(())
         }
         async fn record_run_outcome(
@@ -1811,9 +1975,15 @@ mod tests {
         }
         async fn set_favorited(&self, id: Uuid, is_favorited: bool) -> anyhow::Result<Workflow> {
             let mut wfs = self.workflows.write().await;
-            let wf = wfs.iter_mut().find(|w| w.id == id).ok_or_else(|| {
-                crate::errors::AcsError::NotFound(format!("Workflow with id '{}' not found", id))
-            })?;
+            let wf = wfs
+                .iter_mut()
+                .find(|w| w.id == id && !w.deleted)
+                .ok_or_else(|| {
+                    crate::errors::AcsError::NotFound(format!(
+                        "Workflow with id '{}' not found",
+                        id
+                    ))
+                })?;
             wf.is_favorited = is_favorited;
             wf.updated_at = Utc::now();
             Ok(wf.clone())

--- a/acs/src/server/workflow_routes.rs
+++ b/acs/src/server/workflow_routes.rs
@@ -125,7 +125,7 @@ fn map_store_error(e: anyhow::Error) -> (StatusCode, Json<ErrorResponse>) {
             ),
             // A database constraint / foreign-key violation is a conflict with
             // existing data, not an unexpected internal fault — surface it as a
-            // structured 409 instead of a bare 500 (ACS-25 §6).
+            // structured 409 instead of a bare 500.
             AcsError::Storage(msg)
                 if {
                     let lower = msg.to_lowercase();
@@ -419,7 +419,7 @@ struct DefaultWorkingDirError {
 /// This is the single source of truth for "is this working_dir one we created
 /// and therefore safe to delete on soft-delete". It is used both when filling
 /// in the default on create and when deciding whether to remove the operating
-/// folder on delete (ACS-25).
+/// folder on delete.
 fn derive_default_working_dir(
     config: &crate::models::DaemonConfig,
     name: &str,
@@ -614,7 +614,7 @@ pub async fn list_workflow_costs(
     };
 
     // Include soft-deleted workflows so their persisted cost/token history
-    // remains visible (flagged via `workflow_deleted`) — ACS-25 §5.
+    // remains visible (flagged via `workflow_deleted`).
     let workflows = match state
         .workflow_store
         .list_workflows_including_deleted()
@@ -752,7 +752,7 @@ pub async fn get_workflow_costs(
     };
 
     // Include soft-deleted workflows: their cost history persists and this
-    // endpoint returns 200 with `workflow_deleted: true` (ACS-25 §5).
+    // endpoint returns 200 with `workflow_deleted: true`.
     let workflow = match state
         .workflow_store
         .get_workflow_including_deleted(workflow_id)
@@ -938,7 +938,7 @@ pub async fn delete_workflow(
     let version = wf.version;
     let workflow_name = wf.name.clone();
 
-    // Active-run guard (ACS-25 §2): refuse to soft-delete a workflow that still
+    // Active-run guard: refuse to soft-delete a workflow that still
     // has a run in progress. `list_runs(id, 0, 0)` returns all runs (limit 0 ==
     // no limit).
     match state.workflow_run_store.list_runs(workflow_id, 0, 0).await {
@@ -976,7 +976,7 @@ pub async fn delete_workflow(
     match state.workflow_store.delete_workflow(workflow_id).await {
         Ok(()) => {
             // Best-effort on-disk cleanup AFTER the DB update succeeds. Never
-            // fails the request (ACS-25 §2).
+            // fails the request.
             cleanup_workflow_artifacts(&state, &wf).await;
             // Evict cache entry; cost data recomputes from the persisted runs.
             state.cost_cache.forget(workflow_id).await;
@@ -1000,7 +1000,7 @@ pub async fn delete_workflow(
 
 /// Best-effort removal of on-disk artifacts for a soft-deleted workflow.
 /// Every failure is logged as a warning and swallowed — cleanup must never
-/// fail the delete request (ACS-25 §2).
+/// fail the delete request.
 ///
 ///   a) the run-log directory `<data_dir>/logs/<workflow_id>/`
 ///   b) the operating folder — **only** when the stored `working_dir` equals
@@ -1934,7 +1934,7 @@ mod tests {
             Ok(wf.clone())
         }
         async fn delete_workflow(&self, id: Uuid) -> anyhow::Result<()> {
-            // Soft delete (ACS-25): flag the row instead of removing it so its
+            // Soft delete: flag the row instead of removing it so its
             // cost history persists and its name is freed for reuse.
             let mut wfs = self.workflows.write().await;
             let wf = wfs

--- a/acs/src/storage/sqlite/schema.rs
+++ b/acs/src/storage/sqlite/schema.rs
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS workflows (
     last_run_id         TEXT,
     created_at          TEXT NOT NULL,
     updated_at          TEXT NOT NULL,
-    is_favorited        INTEGER NOT NULL DEFAULT 0
+    is_favorited        INTEGER NOT NULL DEFAULT 0,
+    deleted             INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS workflow_runs (
@@ -146,6 +147,29 @@ mod tests {
             .query_row("PRAGMA synchronous;", [], |r| r.get(0))
             .expect("read synchronous");
         assert_eq!(sync, 1, "synchronous must be NORMAL");
+    }
+
+    #[test]
+    fn test_fresh_schema_has_deleted_column_defaulting_to_zero() {
+        let conn = Connection::open_in_memory().expect("open");
+        apply_pragmas(&conn).expect("pragmas");
+        apply_schema(&conn).expect("schema");
+
+        // Insert without specifying `deleted` — the DEFAULT 0 must apply.
+        conn.execute(
+            "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
+             enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at) \
+             VALUES ('id-1', 'wf', 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', \
+             '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("insert");
+        let deleted: i64 = conn
+            .query_row("SELECT deleted FROM workflows WHERE id = 'id-1'", [], |r| {
+                r.get(0)
+            })
+            .expect("read deleted");
+        assert_eq!(deleted, 0, "deleted must default to 0 on fresh install");
     }
 
     #[test]

--- a/acs/src/storage/sqlite/schema.rs
+++ b/acs/src/storage/sqlite/schema.rs
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS meta (
 "#;
 
 /// Partial unique index enforcing name uniqueness among **live** workflows
-/// only (ACS-25, v4.2.14). Soft-deleted rows are exempt, so a name becomes
+/// only. Soft-deleted rows are exempt, so a name becomes
 /// reusable after its owner is deleted while name resolution stays
 /// unambiguous. Applied *after* [`apply_additive_migrations`] because the
 /// index references the `deleted` column, which older databases only gain
@@ -117,9 +117,9 @@ fn apply_additive_migrations(conn: &Connection) -> Result<(), AcsError> {
     let stmts = [
         // is_favorited added in v4.2.x — pin favorited workflows to the top.
         "ALTER TABLE workflows ADD COLUMN is_favorited INTEGER NOT NULL DEFAULT 0",
-        // deleted added in v4.2.14 (ACS-25) — soft-delete flag. Also added by
-        // the m008 table rebuild; this additive path covers connections that
-        // apply the schema before m008 has run.
+        // deleted — soft-delete flag. Also added by the m008 table rebuild;
+        // this additive path covers connections that apply the schema before
+        // m008 has run.
         "ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
     ];
     for sql in stmts {
@@ -216,7 +216,7 @@ mod tests {
         apply_schema(&conn).expect("schema");
 
         // A soft-deleted row does not reserve its name: a live row with the
-        // same name can coexist (ACS-25 name reuse).
+        // same name can coexist (name reuse after soft-delete).
         let stmt = "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
                     enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at, deleted) \
                     VALUES (?, ?, 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z', ?)";

--- a/acs/src/storage/sqlite/schema.rs
+++ b/acs/src/storage/sqlite/schema.rs
@@ -23,7 +23,7 @@ use crate::errors::AcsError;
 pub const SCHEMA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS workflows (
     id                  TEXT PRIMARY KEY,
-    name                TEXT NOT NULL UNIQUE,
+    name                TEXT NOT NULL,
     version             INTEGER NOT NULL,
     schedule            TEXT NOT NULL,
     timezone            TEXT,
@@ -74,6 +74,15 @@ CREATE TABLE IF NOT EXISTS meta (
 );
 "#;
 
+/// Partial unique index enforcing name uniqueness among **live** workflows
+/// only (ACS-25, v4.2.14). Soft-deleted rows are exempt, so a name becomes
+/// reusable after its owner is deleted while name resolution stays
+/// unambiguous. Applied *after* [`apply_additive_migrations`] because the
+/// index references the `deleted` column, which older databases only gain
+/// through the additive `ALTER TABLE` (or the m008 rebuild).
+pub const LIVE_NAME_INDEX_SQL: &str = "CREATE UNIQUE INDEX IF NOT EXISTS idx_workflows_name_live \
+     ON workflows(name) WHERE deleted = 0";
+
 /// Apply pragmas (WAL, foreign_keys, synchronous) to a freshly-opened
 /// connection. Call this for every `Connection` you open — pragmas are
 /// connection-scoped, not database-scoped.
@@ -91,6 +100,10 @@ pub fn apply_schema(conn: &Connection) -> Result<(), AcsError> {
     conn.execute_batch(SCHEMA_SQL)
         .map_err(|e| AcsError::Storage(format!("Failed to apply schema: {}", e)))?;
     apply_additive_migrations(conn)?;
+    // Must run after the additive migrations: the partial index references the
+    // `deleted` column, which pre-m008 tables only gain via the ALTER above.
+    conn.execute(LIVE_NAME_INDEX_SQL, [])
+        .map_err(|e| AcsError::Storage(format!("Failed to create live-name index: {}", e)))?;
     Ok(())
 }
 
@@ -104,6 +117,10 @@ fn apply_additive_migrations(conn: &Connection) -> Result<(), AcsError> {
     let stmts = [
         // is_favorited added in v4.2.x — pin favorited workflows to the top.
         "ALTER TABLE workflows ADD COLUMN is_favorited INTEGER NOT NULL DEFAULT 0",
+        // deleted added in v4.2.14 (ACS-25) — soft-delete flag. Also added by
+        // the m008 table rebuild; this additive path covers connections that
+        // apply the schema before m008 has run.
+        "ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
     ];
     for sql in stmts {
         if let Err(e) = conn.execute(sql, []) {
@@ -173,18 +190,42 @@ mod tests {
     }
 
     #[test]
-    fn test_workflows_name_uniqueness_enforced() {
+    fn test_workflows_name_uniqueness_enforced_among_live_rows() {
         let conn = Connection::open_in_memory().expect("open");
         apply_pragmas(&conn).expect("pragmas");
         apply_schema(&conn).expect("schema");
 
-        // Insert two rows with the same name — second should fail.
+        // Insert two live rows with the same name — second should fail via the
+        // partial unique index idx_workflows_name_live.
         let stmt = "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
                     enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at) \
                     VALUES (?, ?, 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')";
         conn.execute(stmt, ["id-1", "dup-name"])
             .expect("first insert");
         let result = conn.execute(stmt, ["id-2", "dup-name"]);
-        assert!(result.is_err(), "duplicate name must violate UNIQUE");
+        assert!(
+            result.is_err(),
+            "duplicate live name must violate the partial unique index"
+        );
+    }
+
+    #[test]
+    fn test_workflows_deleted_rows_exempt_from_name_uniqueness() {
+        let conn = Connection::open_in_memory().expect("open");
+        apply_pragmas(&conn).expect("pragmas");
+        apply_schema(&conn).expect("schema");
+
+        // A soft-deleted row does not reserve its name: a live row with the
+        // same name can coexist (ACS-25 name reuse).
+        let stmt = "INSERT INTO workflows (id, name, version, schedule, schedule_mode, \
+                    enabled, steps_json, allow_concurrent, on_failure, created_at, updated_at, deleted) \
+                    VALUES (?, ?, 1, '* * * * *', 'cron', 1, '[]', 1, 'abort', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z', ?)";
+        conn.execute(stmt, rusqlite::params!["id-1", "reused-name", 1i64])
+            .expect("insert deleted row");
+        conn.execute(stmt, rusqlite::params!["id-2", "reused-name", 0i64])
+            .expect("live row with same name must be allowed");
+        // But a second LIVE row with that name still conflicts.
+        let result = conn.execute(stmt, rusqlite::params!["id-3", "reused-name", 0i64]);
+        assert!(result.is_err(), "second live duplicate must be rejected");
     }
 }

--- a/acs/src/storage/sqlite/workflow_runs.rs
+++ b/acs/src/storage/sqlite/workflow_runs.rs
@@ -942,15 +942,10 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-outside").await;
         let tz: Tz = "UTC".parse().unwrap();
-        // 400 days ago — outside the 365-day window
-        seed_raw_run(
-            &run_store,
-            &wf,
-            "Completed",
-            Some("2024-01-01T00:00:00+00:00"),
-            Some(1.0),
-        )
-        .await;
+        // 400 days ago — outside the 365-day window. Computed relative to now
+        // so the test never rots as the calendar advances.
+        let old = (Utc::now() - chrono::Duration::days(400)).to_rfc3339();
+        seed_raw_run(&run_store, &wf, "Completed", Some(&old), Some(1.0)).await;
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
             .await
@@ -965,11 +960,12 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-null-mix").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
+        // Relative to now so the run stays inside the rolling 30-day window.
+        let recent = (Utc::now() - chrono::Duration::days(1)).to_rfc3339();
         // run with cost 0.5
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), Some(0.5)).await;
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), Some(0.5)).await;
         // run with null cost — counted but not summed
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), None).await;
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), None).await;
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
             .await
@@ -985,10 +981,11 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-statuses").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
-        seed_raw_run(&run_store, &wf, "Failed", Some(recent), Some(0.1)).await;
-        seed_raw_run(&run_store, &wf, "Killed", Some(recent), Some(0.2)).await;
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), Some(0.3)).await;
+        // Relative to now so the runs stay inside the rolling 30-day window.
+        let recent = (Utc::now() - chrono::Duration::days(1)).to_rfc3339();
+        seed_raw_run(&run_store, &wf, "Failed", Some(&recent), Some(0.1)).await;
+        seed_raw_run(&run_store, &wf, "Killed", Some(&recent), Some(0.2)).await;
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), Some(0.3)).await;
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
             .await
@@ -1003,8 +1000,10 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-running").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
-        seed_raw_run(&run_store, &wf, "Running", Some(recent), Some(5.0)).await;
+        // Relative to now: the run is inside the window, so a zero count below
+        // proves the Running status (not the date) is what excludes it.
+        let recent = (Utc::now() - chrono::Duration::days(1)).to_rfc3339();
+        seed_raw_run(&run_store, &wf, "Running", Some(&recent), Some(5.0)).await;
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
             .await
@@ -1142,8 +1141,9 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "cost-utc").await;
         let utc_tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T00:00:00+00:00";
-        seed_raw_run(&run_store, &wf, "Completed", Some(recent), Some(1.5)).await;
+        // Relative to now so the run stays inside the rolling 30-day window.
+        let recent = (Utc::now() - chrono::Duration::days(1)).to_rfc3339();
+        seed_raw_run(&run_store, &wf, "Completed", Some(&recent), Some(1.5)).await;
         let summary = run_store
             .cost_summary_for(wf.id, &utc_tz)
             .await
@@ -1452,7 +1452,8 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "tok-summary").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
+        // Relative to now so the runs stay inside the rolling 30-day window.
+        let recent = (Utc::now() - chrono::Duration::days(1)).to_rfc3339();
 
         // Seed three runs: Completed (100 in / 50 out), Failed (200 in / 80 out),
         // Killed (300 in / 120 out).
@@ -1460,15 +1461,24 @@ mod tests {
             &run_store,
             &wf,
             "Completed",
-            Some(recent),
+            Some(&recent),
             Some(0.1),
             100,
             50,
         )
         .await;
-        seed_raw_run_with_tokens(&run_store, &wf, "Failed", Some(recent), Some(0.2), 200, 80).await;
-        seed_raw_run_with_tokens(&run_store, &wf, "Killed", Some(recent), Some(0.3), 300, 120)
+        seed_raw_run_with_tokens(&run_store, &wf, "Failed", Some(&recent), Some(0.2), 200, 80)
             .await;
+        seed_raw_run_with_tokens(
+            &run_store,
+            &wf,
+            "Killed",
+            Some(&recent),
+            Some(0.3),
+            300,
+            120,
+        )
+        .await;
 
         let summary = run_store
             .cost_summary_for(wf.id, &tz)
@@ -1549,11 +1559,14 @@ mod tests {
         let (wf_store, run_store, _db) = SqliteWorkflowRunStore::paired_for_tests();
         let wf = seed_workflow(&wf_store, "tok-zero").await;
         let tz: Tz = "UTC".parse().unwrap();
-        let recent = "2026-05-09T12:00:00+00:00";
+        // Relative to now so the runs stay inside the rolling 30-day window.
+        let recent = (Utc::now() - chrono::Duration::days(1)).to_rfc3339();
 
         // Shell steps produce no tokens — seed runs with 0 for both columns.
-        seed_raw_run_with_tokens(&run_store, &wf, "Completed", Some(recent), Some(0.1), 0, 0).await;
-        seed_raw_run_with_tokens(&run_store, &wf, "Completed", Some(recent), Some(0.2), 0, 0).await;
+        seed_raw_run_with_tokens(&run_store, &wf, "Completed", Some(&recent), Some(0.1), 0, 0)
+            .await;
+        seed_raw_run_with_tokens(&run_store, &wf, "Completed", Some(&recent), Some(0.2), 0, 0)
+            .await;
 
         let summary = run_store
             .cost_summary_for(wf.id, &tz)

--- a/acs/src/storage/sqlite/workflows.rs
+++ b/acs/src/storage/sqlite/workflows.rs
@@ -87,7 +87,7 @@ fn row_to_workflow(row: &Row<'_>) -> rusqlite::Result<Workflow> {
     // is_favorited was added in a later schema migration. Tolerate older rows
     // that don't have the column populated by treating a missing column as false.
     let is_favorited = row.get::<_, i64>("is_favorited").unwrap_or(0) != 0;
-    // `deleted` (soft-delete, ACS-25) — tolerate DBs where the column has not
+    // `deleted` (soft-delete flag) — tolerate DBs where the column has not
     // yet been added by migration m008 (treat missing as not-deleted).
     let deleted = row.get::<_, i64>("deleted").unwrap_or(0) != 0;
 
@@ -155,7 +155,7 @@ impl WorkflowStore for SqliteWorkflowStore {
         let res = self
             .db
             .with_conn(|c| {
-                // Exclude soft-deleted rows (ACS-25).
+                // Exclude soft-deleted rows.
                 let mut stmt = c
                     .prepare("SELECT * FROM workflows WHERE deleted = 0 ORDER BY created_at ASC")
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
@@ -197,7 +197,7 @@ impl WorkflowStore for SqliteWorkflowStore {
         let res = self
             .db
             .with_conn(move |c| {
-                // Exclude soft-deleted rows (ACS-25): a deleted workflow is
+                // Exclude soft-deleted rows: a deleted workflow is
                 // "not found" for the normal endpoints.
                 let mut stmt = c
                     .prepare("SELECT * FROM workflows WHERE id = ? AND deleted = 0")
@@ -232,7 +232,7 @@ impl WorkflowStore for SqliteWorkflowStore {
             .db
             .with_conn(move |c| {
                 // Exclude soft-deleted rows so a reused name resolves to the
-                // live workflow (ACS-25).
+                // live workflow.
                 let mut stmt = c
                     .prepare("SELECT * FROM workflows WHERE name = ? AND deleted = 0")
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
@@ -291,7 +291,7 @@ impl WorkflowStore for SqliteWorkflowStore {
             .with_conn(move |c| {
                 // Fetch existing.
                 let mut wf = {
-                    // Soft-deleted workflows are "not found" for updates (ACS-25).
+                    // Soft-deleted workflows are "not found" for updates.
                     let mut stmt = c
                         .prepare("SELECT * FROM workflows WHERE id = ? AND deleted = 0")
                         .map_err(|e| AcsError::Storage(e.to_string()))?;
@@ -412,7 +412,7 @@ impl WorkflowStore for SqliteWorkflowStore {
         let now_s = Utc::now().to_rfc3339();
         self.db
             .with_conn(move |c| {
-                // Soft delete (ACS-25): flag the row, keep it and every
+                // Soft delete: flag the row, keep it and every
                 // workflow_runs record, and keep the name verbatim — the
                 // partial unique index `idx_workflows_name_live` only covers
                 // rows with deleted = 0, so the name is freed for reuse.
@@ -999,7 +999,7 @@ mod tests {
         assert!(matches!(acs, AcsError::NotFound(_)));
     }
 
-    // ── Soft delete (ACS-25) ────────────────────────────────────────────────
+    // ── Soft delete ─────────────────────────────────────────────────────────
 
     /// A soft-deleted workflow is excluded from `list_workflows`,
     /// `find_by_name`, and `get_workflow` — i.e. it is hidden from the UI and,

--- a/acs/src/storage/sqlite/workflows.rs
+++ b/acs/src/storage/sqlite/workflows.rs
@@ -37,25 +37,6 @@ impl SqliteWorkflowStore {
     }
 }
 
-// ─── Soft-delete name tombstone (ACS-25) ─────────────────────────────────────
-//
-// The `workflows.name` column carries a UNIQUE constraint. On soft-delete we
-// must free that name so a new workflow can reuse it (§4). Rather than rebuild
-// the table to drop the constraint (explicitly out of scope), we rewrite the
-// deleted row's stored name to `"<name>\u{1}<id>"`. The `\u{1}` (SOH) marker
-// cannot appear in a user-entered name, and appending the row id makes every
-// tombstone globally unique. Readers strip everything from the marker onward so
-// the *displayed* name (e.g. in cost views) stays the original value.
-const NAME_TOMBSTONE_MARKER: char = '\u{1}';
-
-/// Recover the display name from a possibly-tombstoned stored name.
-fn strip_name_tombstone(name: String) -> String {
-    match name.split_once(NAME_TOMBSTONE_MARKER) {
-        Some((base, _)) => base.to_string(),
-        None => name,
-    }
-}
-
 // ─── Row mapping ─────────────────────────────────────────────────────────────
 
 fn row_to_workflow(row: &Row<'_>) -> rusqlite::Result<Workflow> {
@@ -112,8 +93,7 @@ fn row_to_workflow(row: &Row<'_>) -> rusqlite::Result<Workflow> {
 
     Ok(Workflow {
         id,
-        // Strip the soft-delete tombstone so the display name is the original.
-        name: strip_name_tombstone(row.get("name")?),
+        name: row.get("name")?,
         version: row.get::<_, i64>("version")? as u32,
         schedule: row.get("schedule")?,
         timezone,
@@ -154,8 +134,10 @@ fn on_failure_blob(p: &FailurePolicy) -> Result<String, AcsError> {
     serde_json::to_string(p).map_err(|e| AcsError::Storage(e.to_string()))
 }
 
-/// Map a rusqlite error during INSERT to an `AcsError`. Specifically detect
-/// the UNIQUE constraint on `workflows.name` and translate to `Conflict`.
+/// Map a rusqlite error during INSERT to an `AcsError`. Specifically detect a
+/// constraint violation — in practice the partial unique index
+/// `idx_workflows_name_live` on `workflows(name) WHERE deleted = 0` — and
+/// translate it to `Conflict` (surfaced as HTTP 409).
 fn map_insert_err(name: &str, e: rusqlite::Error) -> AcsError {
     if let rusqlite::Error::SqliteFailure(ref err, _) = e {
         if err.code == rusqlite::ErrorCode::ConstraintViolation {
@@ -430,28 +412,23 @@ impl WorkflowStore for SqliteWorkflowStore {
         let now_s = Utc::now().to_rfc3339();
         self.db
             .with_conn(move |c| {
-                // Soft delete (ACS-25): keep the row and every workflow_runs
-                // record. Read the current (already display-clean) name so we
-                // can tombstone it and free the UNIQUE slot for reuse.
-                let name: Option<String> = c
-                    .query_row(
-                        "SELECT name FROM workflows WHERE id = ? AND deleted = 0",
-                        [id.to_string()],
-                        |r| r.get(0),
+                // Soft delete (ACS-25): flag the row, keep it and every
+                // workflow_runs record, and keep the name verbatim — the
+                // partial unique index `idx_workflows_name_live` only covers
+                // rows with deleted = 0, so the name is freed for reuse.
+                let n = c
+                    .execute(
+                        "UPDATE workflows SET deleted = 1, updated_at = ?1 \
+                         WHERE id = ?2 AND deleted = 0",
+                        params![now_s, id.to_string()],
                     )
-                    .optional()
-                    .map_err(|e| AcsError::Storage(e.to_string()))?;
-                let name = name.ok_or_else(|| {
-                    AcsError::NotFound(format!("Workflow with id '{}' not found", id))
-                })?;
-
-                let tombstoned = format!("{}{}{}", name, NAME_TOMBSTONE_MARKER, id);
-                c.execute(
-                    "UPDATE workflows SET deleted = 1, name = ?1, updated_at = ?2 \
-                     WHERE id = ?3 AND deleted = 0",
-                    params![tombstoned, now_s, id.to_string()],
-                )
-                .map_err(|e| AcsError::Storage(format!("soft-delete UPDATE failed: {}", e)))?;
+                    .map_err(|e| AcsError::Storage(format!("soft-delete UPDATE failed: {}", e)))?;
+                if n == 0 {
+                    return Err(AcsError::NotFound(format!(
+                        "Workflow with id '{}' not found",
+                        id
+                    )));
+                }
                 Ok(())
             })
             .await?;
@@ -1074,7 +1051,7 @@ mod tests {
         assert!(all[0].deleted, "row must be flagged deleted");
         assert_eq!(
             all[0].name, "sd-cost",
-            "display name is preserved (no tombstone leak)"
+            "deleted rows keep their name verbatim"
         );
 
         let got = store

--- a/acs/src/storage/sqlite/workflows.rs
+++ b/acs/src/storage/sqlite/workflows.rs
@@ -37,6 +37,25 @@ impl SqliteWorkflowStore {
     }
 }
 
+// ─── Soft-delete name tombstone (ACS-25) ─────────────────────────────────────
+//
+// The `workflows.name` column carries a UNIQUE constraint. On soft-delete we
+// must free that name so a new workflow can reuse it (§4). Rather than rebuild
+// the table to drop the constraint (explicitly out of scope), we rewrite the
+// deleted row's stored name to `"<name>\u{1}<id>"`. The `\u{1}` (SOH) marker
+// cannot appear in a user-entered name, and appending the row id makes every
+// tombstone globally unique. Readers strip everything from the marker onward so
+// the *displayed* name (e.g. in cost views) stays the original value.
+const NAME_TOMBSTONE_MARKER: char = '\u{1}';
+
+/// Recover the display name from a possibly-tombstoned stored name.
+fn strip_name_tombstone(name: String) -> String {
+    match name.split_once(NAME_TOMBSTONE_MARKER) {
+        Some((base, _)) => base.to_string(),
+        None => name,
+    }
+}
+
 // ─── Row mapping ─────────────────────────────────────────────────────────────
 
 fn row_to_workflow(row: &Row<'_>) -> rusqlite::Result<Workflow> {
@@ -87,16 +106,21 @@ fn row_to_workflow(row: &Row<'_>) -> rusqlite::Result<Workflow> {
     // is_favorited was added in a later schema migration. Tolerate older rows
     // that don't have the column populated by treating a missing column as false.
     let is_favorited = row.get::<_, i64>("is_favorited").unwrap_or(0) != 0;
+    // `deleted` (soft-delete, ACS-25) — tolerate DBs where the column has not
+    // yet been added by migration m008 (treat missing as not-deleted).
+    let deleted = row.get::<_, i64>("deleted").unwrap_or(0) != 0;
 
     Ok(Workflow {
         id,
-        name: row.get("name")?,
+        // Strip the soft-delete tombstone so the display name is the original.
+        name: strip_name_tombstone(row.get("name")?),
         version: row.get::<_, i64>("version")? as u32,
         schedule: row.get("schedule")?,
         timezone,
         schedule_mode,
         enabled: row.get::<_, i64>("enabled")? != 0,
         is_favorited,
+        deleted,
         steps,
         default_input,
         working_dir: row.get("working_dir")?,
@@ -149,6 +173,27 @@ impl WorkflowStore for SqliteWorkflowStore {
         let res = self
             .db
             .with_conn(|c| {
+                // Exclude soft-deleted rows (ACS-25).
+                let mut stmt = c
+                    .prepare("SELECT * FROM workflows WHERE deleted = 0 ORDER BY created_at ASC")
+                    .map_err(|e| AcsError::Storage(e.to_string()))?;
+                let rows = stmt
+                    .query_map([], row_to_workflow)
+                    .map_err(|e| AcsError::Storage(e.to_string()))?;
+                let mut out = Vec::new();
+                for r in rows {
+                    out.push(r.map_err(|e| AcsError::Storage(e.to_string()))?);
+                }
+                Ok(out)
+            })
+            .await?;
+        Ok(res)
+    }
+
+    async fn list_workflows_including_deleted(&self) -> Result<Vec<Workflow>> {
+        let res = self
+            .db
+            .with_conn(|c| {
                 let mut stmt = c
                     .prepare("SELECT * FROM workflows ORDER BY created_at ASC")
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
@@ -170,6 +215,24 @@ impl WorkflowStore for SqliteWorkflowStore {
         let res = self
             .db
             .with_conn(move |c| {
+                // Exclude soft-deleted rows (ACS-25): a deleted workflow is
+                // "not found" for the normal endpoints.
+                let mut stmt = c
+                    .prepare("SELECT * FROM workflows WHERE id = ? AND deleted = 0")
+                    .map_err(|e| AcsError::Storage(e.to_string()))?;
+                stmt.query_row([&id_s], row_to_workflow)
+                    .optional()
+                    .map_err(|e| AcsError::Storage(e.to_string()))
+            })
+            .await?;
+        Ok(res)
+    }
+
+    async fn get_workflow_including_deleted(&self, id: Uuid) -> Result<Option<Workflow>> {
+        let id_s = id.to_string();
+        let res = self
+            .db
+            .with_conn(move |c| {
                 let mut stmt = c
                     .prepare("SELECT * FROM workflows WHERE id = ?")
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
@@ -186,8 +249,10 @@ impl WorkflowStore for SqliteWorkflowStore {
         let res = self
             .db
             .with_conn(move |c| {
+                // Exclude soft-deleted rows so a reused name resolves to the
+                // live workflow (ACS-25).
                 let mut stmt = c
-                    .prepare("SELECT * FROM workflows WHERE name = ?")
+                    .prepare("SELECT * FROM workflows WHERE name = ? AND deleted = 0")
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
                 stmt.query_row([&name], row_to_workflow)
                     .optional()
@@ -210,6 +275,7 @@ impl WorkflowStore for SqliteWorkflowStore {
             schedule_mode: new.schedule_mode,
             enabled: new.enabled,
             is_favorited: false,
+            deleted: false,
             steps: new.steps,
             default_input: new.default_input,
             working_dir: new.working_dir,
@@ -243,8 +309,9 @@ impl WorkflowStore for SqliteWorkflowStore {
             .with_conn(move |c| {
                 // Fetch existing.
                 let mut wf = {
+                    // Soft-deleted workflows are "not found" for updates (ACS-25).
                     let mut stmt = c
-                        .prepare("SELECT * FROM workflows WHERE id = ?")
+                        .prepare("SELECT * FROM workflows WHERE id = ? AND deleted = 0")
                         .map_err(|e| AcsError::Storage(e.to_string()))?;
                     stmt.query_row([&id.to_string()], row_to_workflow)
                         .optional()
@@ -254,11 +321,12 @@ impl WorkflowStore for SqliteWorkflowStore {
                         })?
                 };
 
-                // Duplicate-name check, excluding self.
+                // Duplicate-name check, excluding self and soft-deleted rows.
                 if let Some(ref new_name) = update.name {
                     let count: i64 = c
                         .query_row(
-                            "SELECT COUNT(*) FROM workflows WHERE name = ? AND id != ?",
+                            "SELECT COUNT(*) FROM workflows \
+                             WHERE name = ? AND id != ? AND deleted = 0",
                             params![new_name, id.to_string()],
                             |r| r.get(0),
                         )
@@ -359,17 +427,31 @@ impl WorkflowStore for SqliteWorkflowStore {
     }
 
     async fn delete_workflow(&self, id: Uuid) -> Result<()> {
+        let now_s = Utc::now().to_rfc3339();
         self.db
             .with_conn(move |c| {
-                let n = c
-                    .execute("DELETE FROM workflows WHERE id = ?", [id.to_string()])
+                // Soft delete (ACS-25): keep the row and every workflow_runs
+                // record. Read the current (already display-clean) name so we
+                // can tombstone it and free the UNIQUE slot for reuse.
+                let name: Option<String> = c
+                    .query_row(
+                        "SELECT name FROM workflows WHERE id = ? AND deleted = 0",
+                        [id.to_string()],
+                        |r| r.get(0),
+                    )
+                    .optional()
                     .map_err(|e| AcsError::Storage(e.to_string()))?;
-                if n == 0 {
-                    return Err(AcsError::NotFound(format!(
-                        "Workflow with id '{}' not found",
-                        id
-                    )));
-                }
+                let name = name.ok_or_else(|| {
+                    AcsError::NotFound(format!("Workflow with id '{}' not found", id))
+                })?;
+
+                let tombstoned = format!("{}{}{}", name, NAME_TOMBSTONE_MARKER, id);
+                c.execute(
+                    "UPDATE workflows SET deleted = 1, name = ?1, updated_at = ?2 \
+                     WHERE id = ?3 AND deleted = 0",
+                    params![tombstoned, now_s, id.to_string()],
+                )
+                .map_err(|e| AcsError::Storage(format!("soft-delete UPDATE failed: {}", e)))?;
                 Ok(())
             })
             .await?;
@@ -386,7 +468,8 @@ impl WorkflowStore for SqliteWorkflowStore {
             .with_conn(move |c| {
                 let n = c
                     .execute(
-                        "UPDATE workflows SET is_favorited = ?1, updated_at = ?2 WHERE id = ?3",
+                        "UPDATE workflows SET is_favorited = ?1, updated_at = ?2 \
+                         WHERE id = ?3 AND deleted = 0",
                         params![fav_i, now_s, id_s],
                     )
                     .map_err(|e| AcsError::Storage(format!("UPDATE is_favorited failed: {}", e)))?;
@@ -937,6 +1020,164 @@ mod tests {
             .expect_err("must error");
         let acs = err.downcast_ref::<AcsError>().expect("must be AcsError");
         assert!(matches!(acs, AcsError::NotFound(_)));
+    }
+
+    // ── Soft delete (ACS-25) ────────────────────────────────────────────────
+
+    /// A soft-deleted workflow is excluded from `list_workflows`,
+    /// `find_by_name`, and `get_workflow` — i.e. it is hidden from the UI and,
+    /// because the scheduler enumerates via `list_workflows`, from scheduling.
+    #[tokio::test]
+    async fn test_soft_delete_excluded_from_list_get_find() {
+        let store = SqliteWorkflowStore::in_memory_for_tests();
+        let created = store
+            .create_workflow(minimal_new_workflow("sd-hidden"))
+            .await
+            .expect("create");
+        store.delete_workflow(created.id).await.expect("delete");
+
+        assert!(
+            store.list_workflows().await.expect("list").is_empty(),
+            "soft-deleted workflow must be absent from list_workflows (and thus the scheduler)"
+        );
+        assert!(
+            store.get_workflow(created.id).await.expect("get").is_none(),
+            "get_workflow must treat a soft-deleted workflow as not found"
+        );
+        assert!(
+            store
+                .find_by_name("sd-hidden")
+                .await
+                .expect("find")
+                .is_none(),
+            "find_by_name must not resolve a soft-deleted workflow"
+        );
+    }
+
+    /// The `*_including_deleted` accessors still surface the row, flagged
+    /// `deleted = true`, so the cost endpoints can report its history.
+    #[tokio::test]
+    async fn test_soft_delete_visible_via_including_deleted() {
+        let store = SqliteWorkflowStore::in_memory_for_tests();
+        let created = store
+            .create_workflow(minimal_new_workflow("sd-cost"))
+            .await
+            .expect("create");
+        assert!(!created.deleted, "fresh workflow is not deleted");
+        store.delete_workflow(created.id).await.expect("delete");
+
+        let all = store
+            .list_workflows_including_deleted()
+            .await
+            .expect("list incl deleted");
+        assert_eq!(all.len(), 1);
+        assert!(all[0].deleted, "row must be flagged deleted");
+        assert_eq!(
+            all[0].name, "sd-cost",
+            "display name is preserved (no tombstone leak)"
+        );
+
+        let got = store
+            .get_workflow_including_deleted(created.id)
+            .await
+            .expect("get incl deleted")
+            .expect("present");
+        assert!(got.deleted);
+        assert_eq!(got.name, "sd-cost");
+    }
+
+    /// Deleting an already-deleted workflow returns NotFound (idempotency at
+    /// the API boundary — the row is gone from the "live" set).
+    #[tokio::test]
+    async fn test_soft_delete_twice_returns_not_found() {
+        let store = SqliteWorkflowStore::in_memory_for_tests();
+        let created = store
+            .create_workflow(minimal_new_workflow("sd-twice"))
+            .await
+            .expect("create");
+        store
+            .delete_workflow(created.id)
+            .await
+            .expect("first delete");
+        let err = store
+            .delete_workflow(created.id)
+            .await
+            .expect_err("second delete must fail");
+        let acs = err.downcast_ref::<AcsError>().expect("AcsError");
+        assert!(matches!(acs, AcsError::NotFound(_)));
+    }
+
+    /// A name can be reused after its owner is soft-deleted; the two workflows
+    /// remain distinct rows (distinct ids), so cost views key by id stay
+    /// separate.
+    #[tokio::test]
+    async fn test_soft_delete_frees_name_for_reuse() {
+        let store = SqliteWorkflowStore::in_memory_for_tests();
+        let first = store
+            .create_workflow(minimal_new_workflow("reuse-me"))
+            .await
+            .expect("create first");
+        store.delete_workflow(first.id).await.expect("delete first");
+
+        // Recreating with the same name must succeed (the UNIQUE slot is freed).
+        let second = store
+            .create_workflow(minimal_new_workflow("reuse-me"))
+            .await
+            .expect("recreate same name");
+        assert_ne!(first.id, second.id, "recreated workflow has a new id");
+
+        // find_by_name resolves the live one; list shows only the live one.
+        let found = store
+            .find_by_name("reuse-me")
+            .await
+            .expect("find")
+            .expect("present");
+        assert_eq!(found.id, second.id);
+        let live = store.list_workflows().await.expect("list");
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].id, second.id);
+
+        // Both rows survive for cost purposes, keyed by distinct ids.
+        let all = store
+            .list_workflows_including_deleted()
+            .await
+            .expect("list incl deleted");
+        assert_eq!(all.len(), 2, "deleted + live rows both persist");
+    }
+
+    /// Updating or favoriting a soft-deleted workflow is a NotFound.
+    #[tokio::test]
+    async fn test_update_and_favorite_on_deleted_return_not_found() {
+        let store = SqliteWorkflowStore::in_memory_for_tests();
+        let created = store
+            .create_workflow(minimal_new_workflow("sd-upd"))
+            .await
+            .expect("create");
+        store.delete_workflow(created.id).await.expect("delete");
+
+        let upd_err = store
+            .update_workflow(
+                created.id,
+                WorkflowUpdate {
+                    enabled: Some(false),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("update must fail");
+        assert!(matches!(
+            upd_err.downcast_ref::<AcsError>().expect("AcsError"),
+            AcsError::NotFound(_)
+        ));
+
+        let fav_err = store
+            .set_favorited(created.id, true)
+            .await
+            .expect_err("favorite must fail");
+        assert!(matches!(
+            fav_err.downcast_ref::<AcsError>().expect("AcsError"),
+            AcsError::NotFound(_)
+        ));
     }
 
     // ── List ──────────────────────────────────────────────────────────────────

--- a/acs/src/storage/workflows.rs
+++ b/acs/src/storage/workflows.rs
@@ -10,7 +10,7 @@ use crate::models::workflow::{NewWorkflow, RunStatus, Workflow, WorkflowUpdate};
 #[async_trait]
 pub trait WorkflowStore: Send + Sync {
     /// List all **live** (non-deleted) workflows. Soft-deleted workflows
-    /// (ACS-25) are excluded so they disappear from the UI, scheduler, and
+    /// are excluded so they disappear from the UI, scheduler, and
     /// name resolution.
     async fn list_workflows(&self) -> Result<Vec<Workflow>>;
 
@@ -32,7 +32,7 @@ pub trait WorkflowStore: Send + Sync {
     async fn create_workflow(&self, new: NewWorkflow) -> Result<Workflow>;
     async fn update_workflow(&self, id: Uuid, update: WorkflowUpdate) -> Result<Workflow>;
 
-    /// Soft-delete a workflow (ACS-25): flag the row `deleted = 1` and release
+    /// Soft-delete a workflow: flag the row `deleted = 1` and release
     /// its unique name so the name can be reused, while keeping the row and all
     /// of its `workflow_runs` so cost history survives. Returns
     /// `AcsError::NotFound` if the id does not match a live workflow.

--- a/acs/src/storage/workflows.rs
+++ b/acs/src/storage/workflows.rs
@@ -9,11 +9,33 @@ use crate::models::workflow::{NewWorkflow, RunStatus, Workflow, WorkflowUpdate};
 
 #[async_trait]
 pub trait WorkflowStore: Send + Sync {
+    /// List all **live** (non-deleted) workflows. Soft-deleted workflows
+    /// (ACS-25) are excluded so they disappear from the UI, scheduler, and
+    /// name resolution.
     async fn list_workflows(&self) -> Result<Vec<Workflow>>;
+
+    /// List every workflow row, **including** soft-deleted ones. Used only by
+    /// the cost endpoints, which must keep surfacing the persisted cost/token
+    /// history of deleted workflows (flagged via `Workflow::deleted`).
+    async fn list_workflows_including_deleted(&self) -> Result<Vec<Workflow>>;
+
+    /// Fetch a single **live** workflow. Returns `None` for a missing row *or*
+    /// a soft-deleted one — deleted workflows behave as "not found".
     async fn get_workflow(&self, id: Uuid) -> Result<Option<Workflow>>;
+
+    /// Fetch a single workflow row **including** soft-deleted ones. Used by the
+    /// per-id cost endpoint so cost history for a deleted workflow is still
+    /// returned (200 with `workflow_deleted: true`).
+    async fn get_workflow_including_deleted(&self, id: Uuid) -> Result<Option<Workflow>>;
+
     async fn find_by_name(&self, name: &str) -> Result<Option<Workflow>>;
     async fn create_workflow(&self, new: NewWorkflow) -> Result<Workflow>;
     async fn update_workflow(&self, id: Uuid, update: WorkflowUpdate) -> Result<Workflow>;
+
+    /// Soft-delete a workflow (ACS-25): flag the row `deleted = 1` and release
+    /// its unique name so the name can be reused, while keeping the row and all
+    /// of its `workflow_runs` so cost history survives. Returns
+    /// `AcsError::NotFound` if the id does not match a live workflow.
     async fn delete_workflow(&self, id: Uuid) -> Result<()>;
 
     /// Record the terminal outcome of a run on its parent workflow.

--- a/acs/src/workflow/executor.rs
+++ b/acs/src/workflow/executor.rs
@@ -1035,6 +1035,7 @@ mod tests {
             schedule_mode: ScheduleMode::default(),
             enabled: true,
             is_favorited: false,
+            deleted: false,
             steps,
             default_input: None,
             working_dir: None,

--- a/acs/tests/workflow_api_tests.rs
+++ b/acs/tests/workflow_api_tests.rs
@@ -5000,3 +5000,405 @@ async fn test_cost_summary_avg_equals_total_over_runs() {
         sruns_30
     );
 }
+
+// ---------------------------------------------------------------------------
+// Soft-delete tests (ACS-25)
+// ---------------------------------------------------------------------------
+
+/// SD-1. Soft-deleting a workflow that has run history returns 204, hides the
+///       workflow from GET/list, keeps the runs queryable, and keeps its cost
+///       history visible (flagged `workflow_deleted: true`).
+#[tokio::test]
+async fn test_soft_delete_preserves_runs_and_cost() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("sd-preserve")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap().to_string();
+    let wf_id = Uuid::parse_str(&wf_id_str).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+
+    let run_id = insert_terminal_run(
+        &run_store,
+        wf_id,
+        &wf,
+        RunStatus::Completed,
+        Utc::now() - Duration::days(1),
+        Some(0.42),
+    )
+    .await;
+
+    // DELETE → 204 even though run history exists (regression: used to 500 on
+    // the FOREIGN KEY constraint).
+    let del = client
+        .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("DELETE");
+    assert_eq!(
+        del.status(),
+        204,
+        "soft delete with run history must be 204"
+    );
+
+    // GET by id → 404; absent from list.
+    assert_eq!(
+        client
+            .get(format!("{}/api/workflows/{}", base_url, wf_id_str))
+            .send()
+            .await
+            .expect("GET")
+            .status(),
+        404
+    );
+    let list: serde_json::Value = client
+        .get(format!("{}/api/workflows", base_url))
+        .send()
+        .await
+        .expect("GET list")
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        list.as_array().unwrap().is_empty(),
+        "deleted workflow must be absent from the list"
+    );
+
+    // The run is still queryable.
+    let run_resp = client
+        .get(format!("{}/api/runs/{}", base_url, run_id))
+        .send()
+        .await
+        .expect("GET run");
+    assert_eq!(
+        run_resp.status(),
+        200,
+        "runs must survive workflow deletion"
+    );
+
+    // Per-id cost endpoint → 200 with workflow_deleted: true and the run's cost.
+    let cost: serde_json::Value = client
+        .get(format!("{}/api/cost/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("GET cost by id")
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(cost["workflow_deleted"], true, "flag must be true");
+    assert_eq!(cost["cost_summary"]["last_30_days_runs"], 1);
+
+    // Cost list includes the deleted workflow, flagged.
+    let cost_list: serde_json::Value = client
+        .get(format!("{}/api/cost/workflows", base_url))
+        .send()
+        .await
+        .expect("GET cost list")
+        .json()
+        .await
+        .unwrap();
+    let entry = cost_list["workflows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["workflow_id"] == serde_json::json!(wf_id_str))
+        .expect("deleted workflow present in cost list");
+    assert_eq!(entry["workflow_deleted"], true);
+}
+
+/// SD-2. Deleting a workflow with an active (Running) run is rejected with 409
+///       and the workflow is left intact.
+#[tokio::test]
+async fn test_delete_workflow_with_active_run_returns_409() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("sd-active")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap().to_string();
+    let wf_id = Uuid::parse_str(&wf_id_str).unwrap();
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+
+    insert_running_run(&run_store, wf_id, &wf).await;
+
+    let del = client
+        .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
+        .send()
+        .await
+        .expect("DELETE");
+    assert_eq!(del.status(), 409, "active run must block delete");
+    let body: serde_json::Value = del.json().await.unwrap();
+    assert_eq!(body["error"], "workflow_run_active");
+
+    // Workflow still exists.
+    assert_eq!(
+        client
+            .get(format!("{}/api/workflows/{}", base_url, wf_id_str))
+            .send()
+            .await
+            .expect("GET")
+            .status(),
+        200,
+        "workflow must remain after a blocked delete"
+    );
+}
+
+/// SD-3. A name can be reused after soft-delete, and the cost list then shows
+///       two separate entries (deleted + live) that key by distinct ids.
+#[tokio::test]
+async fn test_name_reuse_after_soft_delete_shows_two_cost_entries() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    // Create → run → delete.
+    let first: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("reuse-name")).unwrap())
+        .send()
+        .await
+        .expect("POST 1")
+        .json()
+        .await
+        .unwrap();
+    let first_id = first["id"].as_str().unwrap().to_string();
+    let first_uuid = Uuid::parse_str(&first_id).unwrap();
+    let first_wf = wf_store.get_workflow(first_uuid).await.unwrap().unwrap();
+    insert_terminal_run(
+        &run_store,
+        first_uuid,
+        &first_wf,
+        RunStatus::Completed,
+        Utc::now() - Duration::days(1),
+        Some(0.10),
+    )
+    .await;
+    assert_eq!(
+        client
+            .delete(format!("{}/api/workflows/{}", base_url, first_id))
+            .send()
+            .await
+            .expect("DELETE")
+            .status(),
+        204
+    );
+
+    // Recreate the same name — must succeed with a new id.
+    let second: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("reuse-name")).unwrap())
+        .send()
+        .await
+        .expect("POST 2")
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(second.get("error"), None, "recreate must not conflict");
+    let second_id = second["id"].as_str().unwrap().to_string();
+    assert_ne!(second_id, first_id, "reused name gets a new id");
+    let second_uuid = Uuid::parse_str(&second_id).unwrap();
+    let second_wf = wf_store.get_workflow(second_uuid).await.unwrap().unwrap();
+    insert_terminal_run(
+        &run_store,
+        second_uuid,
+        &second_wf,
+        RunStatus::Completed,
+        Utc::now() - Duration::days(1),
+        Some(0.20),
+    )
+    .await;
+
+    // Cost list shows two separate entries with the same name.
+    let cost_list: serde_json::Value = client
+        .get(format!("{}/api/cost/workflows", base_url))
+        .send()
+        .await
+        .expect("GET cost list")
+        .json()
+        .await
+        .unwrap();
+    let entries: Vec<&serde_json::Value> = cost_list["workflows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["workflow_name"] == serde_json::json!("reuse-name"))
+        .collect();
+    assert_eq!(entries.len(), 2, "expected a deleted + a live entry");
+    let deleted_entry = entries
+        .iter()
+        .find(|e| e["workflow_id"] == serde_json::json!(first_id))
+        .expect("deleted entry");
+    let live_entry = entries
+        .iter()
+        .find(|e| e["workflow_id"] == serde_json::json!(second_id))
+        .expect("live entry");
+    assert_eq!(deleted_entry["workflow_deleted"], true);
+    assert_eq!(live_entry["workflow_deleted"], false);
+}
+
+/// SD-4. On soft-delete, the run-log directory and the ACS-managed default
+///       operating folder are removed, and the run-log endpoint no longer 500s.
+#[tokio::test]
+async fn test_soft_delete_removes_default_working_dir_and_log_dir() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let data_dir = tmp.path().to_path_buf();
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        data_dir.clone(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&make_new_workflow("sd-wd-default")).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap().to_string();
+    let wf_id = Uuid::parse_str(&wf_id_str).unwrap();
+
+    // The default working_dir was created on disk under the test's workflow_dirs.
+    let working_dir = created["working_dir"].as_str().unwrap().to_string();
+    let working_dir_path = std::path::PathBuf::from(&working_dir);
+    assert!(
+        working_dir_path.exists(),
+        "default working_dir should exist after create"
+    );
+
+    // Fabricate a run-log directory as the trigger path would.
+    let log_dir = data_dir.join("logs").join(&wf_id_str);
+    std::fs::create_dir_all(&log_dir).expect("create log dir");
+    std::fs::write(log_dir.join("some.log"), b"log data").expect("write log file");
+
+    // Seed a terminal run so there is a run row (its log file is gone below).
+    let wf = wf_store.get_workflow(wf_id).await.unwrap().unwrap();
+    let run_id = insert_terminal_run(
+        &run_store,
+        wf_id,
+        &wf,
+        RunStatus::Completed,
+        Utc::now() - Duration::days(1),
+        Some(0.05),
+    )
+    .await;
+
+    assert_eq!(
+        client
+            .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
+            .send()
+            .await
+            .expect("DELETE")
+            .status(),
+        204
+    );
+
+    assert!(
+        !working_dir_path.exists(),
+        "ACS-managed default working_dir must be removed on delete"
+    );
+    assert!(
+        !log_dir.exists(),
+        "run-log directory must be removed on delete"
+    );
+
+    // The run-log endpoint must not 500 now that the file is gone (404 is ok).
+    let log_resp = client
+        .get(format!("{}/api/runs/{}/log", base_url, run_id))
+        .send()
+        .await
+        .expect("GET run log");
+    assert_eq!(
+        log_resp.status(),
+        404,
+        "missing log after delete should be 404, never 500"
+    );
+}
+
+/// SD-5. A custom (user-specified) working_dir is NEVER touched on delete.
+#[tokio::test]
+async fn test_soft_delete_preserves_custom_working_dir() {
+    let (wf_store, run_store, tmp) = make_stores().await;
+    let (base_url, _state, _handle) = spawn_test_server(
+        Arc::clone(&wf_store),
+        Arc::clone(&run_store),
+        tmp.path().to_path_buf(),
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    // A custom directory that is NOT the ACS-managed default.
+    let custom_dir = tmp.path().join("my-custom-dir");
+    std::fs::create_dir_all(&custom_dir).expect("create custom dir");
+
+    let mut body = make_new_workflow("sd-wd-custom");
+    body.working_dir = Some(custom_dir.to_string_lossy().into_owned());
+
+    let created: serde_json::Value = client
+        .post(format!("{}/api/workflows", base_url))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&body).unwrap())
+        .send()
+        .await
+        .expect("POST")
+        .json()
+        .await
+        .unwrap();
+    let wf_id_str = created["id"].as_str().unwrap().to_string();
+
+    assert_eq!(
+        client
+            .delete(format!("{}/api/workflows/{}", base_url, wf_id_str))
+            .send()
+            .await
+            .expect("DELETE")
+            .status(),
+        204
+    );
+
+    assert!(
+        custom_dir.exists(),
+        "a custom working_dir must never be deleted on soft-delete"
+    );
+}

--- a/acs/tests/workflow_api_tests.rs
+++ b/acs/tests/workflow_api_tests.rs
@@ -5002,7 +5002,7 @@ async fn test_cost_summary_avg_equals_total_over_runs() {
 }
 
 // ---------------------------------------------------------------------------
-// Soft-delete tests (ACS-25)
+// Soft-delete tests
 // ---------------------------------------------------------------------------
 
 /// SD-1. Soft-deleting a workflow that has run history returns 204, hides the

--- a/acs/web/openapi.yaml
+++ b/acs/web/openapi.yaml
@@ -7,7 +7,7 @@ info:
     ACS is a multi-step workflow scheduler with a built-in HTTP API and web UI.
     Workflows can be identified by either their UUID or their unique name in all
     endpoints that accept an `{id}` path parameter.
-  version: "4.2.13"
+  version: "4.2.14"
   license:
     name: MIT
 
@@ -49,7 +49,7 @@ paths:
                 uptime_seconds: 3600
                 active_jobs: 5
                 total_jobs: 8
-                version: "4.2.13"
+                version: "4.2.14"
                 data_dir: "C:\\Users\\J\\AppData\\Local\\acs\\data"
                 service:
                   registered: true
@@ -268,18 +268,42 @@ paths:
 
     delete:
       operationId: deleteWorkflow
-      summary: Delete a workflow
+      summary: Delete a workflow (soft delete)
       description: |
-        Deletes a workflow by ID or name. If the workflow has an active run it
-        will be killed before deletion. Returns 204 on success with no body.
+        Soft-deletes a workflow by ID or name (v4.2.14, ACS-25). The workflow
+        row and **all** of its `workflow_runs` are kept — the run rows are the
+        cost/token record — and the workflow is flagged as deleted. It then
+        disappears from `GET /api/workflows`, name resolution, the scheduler,
+        and triggering (all behave as 404), and its name is freed for reuse.
+
+        Its persisted cost history remains available via `GET /api/cost/workflows`
+        and `GET /api/cost/workflows/{id}` (flagged `workflow_deleted: true`),
+        and its runs remain readable via `GET /api/runs/{run_id}`.
+
+        On-disk artifacts are removed best-effort after the DB update succeeds:
+        the run-log directory `<data_dir>/logs/<workflow_id>/`, and the
+        operating folder **only** when it is the ACS-managed default path — a
+        custom `working_dir` is never touched.
+
+        If the workflow currently has a **Running** run, the request is rejected
+        with `409 Conflict` (`error: "workflow_run_active"`); kill or wait for
+        the run to finish, then retry. Returns 204 on success with no body.
       tags: [Workflows]
       parameters:
         - $ref: "#/components/parameters/WorkflowId"
       responses:
         "204":
-          description: Workflow deleted (no content)
+          description: Workflow soft-deleted (no content)
         "404":
           description: Workflow not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: |
+            The workflow has a run in progress and cannot be deleted
+            (`error: "workflow_run_active"`).
           content:
             application/json:
               schema:
@@ -1665,6 +1689,13 @@ components:
           type: string
           description: Workflow name.
           example: deploy-pipeline
+        workflow_deleted:
+          type: boolean
+          default: false
+          description: |
+            `true` when the parent workflow has been soft-deleted (v4.2.14).
+            Cost/token history is aggregated from the persisted `workflow_runs`
+            rows, so deleted workflows are still listed here.
         cost_summary:
           $ref: "#/components/schemas/CostSummary"
 
@@ -1706,6 +1737,13 @@ components:
           type: string
           description: Workflow name.
           example: deploy-pipeline
+        workflow_deleted:
+          type: boolean
+          default: false
+          description: |
+            `true` when the workflow has been soft-deleted (v4.2.14). This
+            endpoint still returns 200 with the persisted cost history for a
+            deleted workflow.
         cost_summary:
           $ref: "#/components/schemas/CostSummary"
 

--- a/acs/web/openapi.yaml
+++ b/acs/web/openapi.yaml
@@ -270,7 +270,7 @@ paths:
       operationId: deleteWorkflow
       summary: Delete a workflow (soft delete)
       description: |
-        Soft-deletes a workflow by ID or name (v4.2.14, ACS-25). The workflow
+        Soft-deletes a workflow by ID or name. The workflow
         row and **all** of its `workflow_runs` are kept — the run rows are the
         cost/token record — and the workflow is flagged as deleted. It then
         disappears from `GET /api/workflows`, name resolution, the scheduler,
@@ -1084,7 +1084,7 @@ components:
         version:
           type: string
           description: Daemon version string.
-          example: "4.2.13"
+          example: "4.2.14"
         data_dir:
           type: string
           description: Filesystem path to the data directory.
@@ -1693,7 +1693,7 @@ components:
           type: boolean
           default: false
           description: |
-            `true` when the parent workflow has been soft-deleted (v4.2.14).
+            `true` when the parent workflow has been soft-deleted.
             Cost/token history is aggregated from the persisted `workflow_runs`
             rows, so deleted workflows are still listed here.
         cost_summary:
@@ -1741,7 +1741,7 @@ components:
           type: boolean
           default: false
           description: |
-            `true` when the workflow has been soft-deleted (v4.2.14). This
+            `true` when the workflow has been soft-deleted. This
             endpoint still returns 200 with the persisted cost history for a
             deleted workflow.
         cost_summary:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -124,7 +124,7 @@ Returns daemon health status, including uptime, workflow counts, version, and pl
   "uptime_seconds": 3600,
   "active_jobs": 5,
   "total_jobs": 8,
-  "version": "4.2.13",
+  "version": "4.2.14",
   "data_dir": "/home/user/.local/share/agent-cron-scheduler",
   "service": {
     "registered": true,
@@ -317,7 +317,15 @@ Partially update an existing workflow. Only the fields you include in the reques
 
 ### DELETE /api/workflows/{id}
 
-Delete a workflow.
+Soft-delete a workflow (v4.2.14, ACS-25).
+
+The workflow row and **all** of its runs are kept — the `workflow_runs` rows are
+the cost/token record — and the workflow is flagged as deleted. It then
+disappears from [GET /api/workflows](#get-apiworkflows), name resolution, the
+scheduler, and triggering (all behave as 404), and its **name is freed for
+reuse**. Its persisted cost history stays available via the cost endpoints
+(flagged `workflow_deleted: true`), and its runs stay readable via
+[GET /api/runs/{run_id}](#get-apirunsrun_id).
 
 **Path Parameters:**
 
@@ -331,11 +339,19 @@ Delete a workflow.
 
 | Status | Description |
 |--------|-------------|
-| 204 No Content | Workflow deleted. No response body. |
+| 204 No Content | Workflow soft-deleted. No response body. |
 | 404 Not Found | Workflow not found. |
+| 409 Conflict | The workflow has a run in progress (`error: "workflow_run_active"`). Kill or wait for the run, then retry. |
 | 500 Internal Server Error | Storage failure. |
 
-**Side effects:** Broadcasts a `WorkflowChanged` SSE event with `change_kind: "deleted"`.
+**Side effects:**
+
+- Best-effort on-disk cleanup after the DB update succeeds: the run-log
+  directory `<data_dir>/logs/<workflow_id>/` is removed, and the operating
+  folder is removed **only** when it is the ACS-managed default path — a
+  custom `working_dir` is never touched. Cleanup failures are logged, never
+  fail the request.
+- Broadcasts a `WorkflowChanged` SSE event with `change_kind: "deleted"`.
 
 ---
 
@@ -1074,6 +1090,7 @@ A single workflow's cost data as returned in `CostWorkflowsListResponse.workflow
 |---|---|---|
 | `workflow_id` | string (UUID) | The workflow identifier. |
 | `workflow_name` | string | The workflow name (slug). |
+| `workflow_deleted` | bool | `true` when the parent workflow has been soft-deleted (v4.2.14). Cost history is aggregated from persisted `workflow_runs`, so deleted workflows are still listed. Defaults to `false`. |
 | `cost_summary` | [CostSummary](#costsummary) | Aggregated cost analytics for this workflow (30-day totals, 1-year totals, and `daily_buckets` for the requested window). |
 
 ---
@@ -1097,6 +1114,7 @@ Response shape for `GET /api/cost/workflows/{id}`.
 |---|---|---|
 | `workflow_id` | string (UUID) | The workflow identifier. |
 | `workflow_name` | string | The workflow name (slug). |
+| `workflow_deleted` | bool | `true` when the workflow has been soft-deleted (v4.2.14). This endpoint still returns 200 with the persisted cost history. Defaults to `false`. |
 | `cost_summary` | [CostSummary](#costsummary) | Aggregated cost analytics for this workflow (30-day totals, 1-year totals, and `daily_buckets` for the requested window). |
 
 ---

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -317,7 +317,7 @@ Partially update an existing workflow. Only the fields you include in the reques
 
 ### DELETE /api/workflows/{id}
 
-Soft-delete a workflow (v4.2.14, ACS-25).
+Soft-delete a workflow (v4.2.14).
 
 The workflow row and **all** of its runs are kept — the `workflow_runs` rows are
 the cost/token record — and the workflow is flagged as deleted. It then

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -28,8 +28,10 @@ The three active store traits are:
 | *(daemon)* | `SizeManagedWriter` | Daemon process log (`daemon.log`) |
 
 Step output is written by `FileLogSink` (not through a store trait) to per-run
-files under `logs/`.  Migration state is maintained in a standalone
-`migrations.json` file managed by the migration runner.
+files under `logs/`.  Migration execution is tracked in the
+`schema_migrations` table inside `acs.db`, owned by the migration runner
+(the standalone `migrations.json` file is legacy — see
+[Migration System](#9-migration-system)).
 
 ---
 
@@ -44,7 +46,7 @@ files under `logs/`.  Migration state is maintained in a standalone
 ├── acs.db                      # SQLite database holding workflows + workflow_runs tables
 ├── acs.db-wal                  # SQLite write-ahead log (created at runtime, managed by SQLite)
 ├── acs.db-shm                  # SQLite shared memory file (created at runtime, managed by SQLite)
-├── migrations.json             # Applied-migration state for the numbered migration runner
+├── migrations.json             # Legacy migration state; read once to backfill schema_migrations, never written again
 ├── jobs.json.migrated.<ts>     # Backup of legacy jobs.json after m001 runs (unix timestamp suffix)
 ├── migrated_scripts/           # Created on demand by m001 migration when migrating non-shell hooks
 ├── scripts/                    # Reserved directory (created on startup; not currently used)
@@ -55,9 +57,11 @@ files under `logs/`.  Migration state is maintained in a standalone
 
 On daemon startup, `create_data_dirs()` ensures the top-level directory and
 the `logs/` and `scripts/` subdirectories exist.  The `acs.db` file is created
-by the `m002_json_to_sqlite` migration when the daemon first runs.  The
-`acs.db-wal` and `acs.db-shm` sidecar files are created by SQLite the first
-time the database is opened in WAL mode and persist alongside the DB.
+by the migration runner (to host its `schema_migrations` tracking table)
+before any migration runs; the `m002_json_to_sqlite` migration then applies
+the full data schema when the daemon first runs.  The `acs.db-wal` and
+`acs.db-shm` sidecar files are created by SQLite the first time the database
+is opened in WAL mode and persist alongside the DB.
 
 ---
 
@@ -196,12 +200,15 @@ is silently dropped.  Recovery is operator-driven: restore from a known-good
 backup of the data directory.  Because every transaction is atomic, partial
 writes from a crash never leave the database structurally inconsistent.
 
-### `migrations.json`
+### Migration tracking state
 
-If `migrations.json` is missing or contains invalid JSON, `read_state()`
-returns an empty `HashSet`, treating the daemon as if no migrations have been
-applied.  **No backup file is created**; a corrupt state simply causes
-pending migrations to re-run (each migration's `run()` method is idempotent).
+Migration execution is tracked in the `schema_migrations` table inside
+`acs.db`, protected by the same SQLite atomicity guarantees as the data
+tables.  The legacy `migrations.json` file is read exactly once — to backfill
+the tracking table on databases that predate it.  If it is missing or
+contains invalid JSON at that moment, the backfill seeds nothing and every
+migration runs normally; each migration's internal idempotency makes that
+safe on an already-migrated database.
 
 ---
 
@@ -503,46 +510,76 @@ pub trait Migration: Send + Sync {
 
 `run()` must be **idempotent** — re-running on already-migrated data must be a
 no-op.  It returns `Ok(true)` when work was performed, or `Ok(false)` when
-there was nothing to do.
+there was nothing to do.  The runner records `success` either way; the return
+value only affects logging.  The internal idempotency checks are a safety
+property (they make the delete-row-and-re-run workflow below harmless) — the
+runner never consults them to decide execution.
 
-### State file
+### Tracking table: `schema_migrations`
 
-Applied migration names are tracked in `{data_dir}/migrations.json`:
+Migration execution is tracked by name in a `schema_migrations` table inside
+`{data_dir}/acs.db`.  The table is created by the **runner itself** — not by a
+migration — before any migration logic runs:
 
-```json
-{
-  "applied": [
-    "m001_jobs_to_workflows",
-    "m002_json_to_sqlite",
-    "m003_drop_step_output_summary",
-    "m004_drop_input_schema",
-    "m005_shell_claude_to_agent",
-    "m006_agent_step_normalize",
-    "m007_add_token_columns"
-  ]
-}
+```sql
+CREATE TABLE schema_migrations (
+    name        TEXT PRIMARY KEY,             -- stable migration name, e.g. "m008_add_workflow_deleted"
+    applied_at  TEXT NOT NULL,                -- RFC 3339 timestamp of the recording
+    status      TEXT NOT NULL CHECK (status IN ('success','failed')),
+    duration_ms INTEGER,                      -- wall-clock run time; NULL for backfilled rows
+    error       TEXT                          -- error text for failed rows; NULL otherwise
+);
 ```
 
-Migration status is **not** exposed through `/health`. The on-disk
-`migrations.json` is the only structured surface; per-migration outcomes are
-also written to `daemon.log` via `tracing::info!` lines (e.g.
+Migration status is **not** exposed through `/health`.  The table is the only
+structured surface; per-migration outcomes are also written to `daemon.log`
+via `tracing::info!` lines (e.g.
 `"Migration m003 complete: stripped output_summary from N workflow_runs row(s)"`).
-
-`run_pending()` reads this file at daemon startup, skips already-applied
-migrations, and writes the updated state after each successful migration.
-Writes are atomic (`.tmp` + rename).
-
-If the file is missing, `read_state()` returns an empty set (fresh install).
-If the file is corrupt, `read_state()` logs a warning and returns an empty set
-(safe to re-run migrations; each is idempotent).
 
 ### Runner behaviour
 
-`run_pending()` iterates the registry in order.  On the first migration error
-it stops and propagates the error; partial progress (applied migrations before
-the failure) is preserved in the state file.  Migrations that return
-`Ok(false)` (nothing to do) are recorded in `skipped_not_needed` but are
-**not** added to the applied set.
+`run_pending()` iterates the registry in order.  The tracking table — and only
+the tracking table — decides what executes:
+
+| Row state for a migration | Action |
+|---|---|
+| No row | Run it, then record `success` or `failed` |
+| `status = 'success'` | Skip without invoking the migration |
+| `status = 'failed'` | **Abort daemon startup** with an error naming the migration |
+
+A migration that runs but finds nothing to do (e.g. legacy format absent)
+still records `success` — the row means "processed", so it never re-runs.  On
+failure the row is recorded with status `failed` and the error text, and the
+runner aborts immediately: later migrations do not run and get no row.
+
+**Recovery workflow for a failed migration** (this is the sanctioned dev
+workflow): fix the underlying issue, then delete the tracking row so the next
+startup re-runs it:
+
+```sql
+DELETE FROM schema_migrations WHERE name = '<migration name>';
+```
+
+The same mechanism re-runs any migration whose `success` row is deleted —
+safe, because every migration is internally idempotent.
+
+### Backfill from legacy `migrations.json`
+
+Databases that predate the tracking table recorded applied migrations in
+`{data_dir}/migrations.json`:
+
+```json
+{ "applied": ["m001_jobs_to_workflows", "m002_json_to_sqlite"] }
+```
+
+The first time the runner creates the tracking table it seeds a `success` row
+for every registry migration named in that file — those are treated as
+already applied without being invoked.  Every other migration then runs
+normally; on an already-migrated database their internal idempotency makes
+that a safe no-op, recorded as `success`.  After this one-time backfill the
+table is the sole source of truth: `migrations.json` is left on disk but
+never written (or read) again.  A fresh install has no legacy file, so all
+migrations simply run once and end recorded as `success`.
 
 ### Adding a migration
 
@@ -597,8 +634,8 @@ earlier daemon versions.
 
 | Condition | Action |
 |---|---|
-| `acs.db` already exists | No-op (return `Ok(false)`) |
-| Neither `workflows.json` nor `runs/` exists | Create empty `acs.db` with the schema applied, return `Ok(true)` |
+| `acs.db` contains a `workflows` table | No-op (return `Ok(false)`) — conversion or fresh-install schema already in place. Table-based rather than file-based because the migration runner creates `acs.db` up front to host `schema_migrations`. |
+| Neither `workflows.json` nor `runs/` exists | Apply the schema to `acs.db`, return `Ok(true)` |
 | Otherwise | Open `acs.db`, BEGIN transaction, INSERT every workflow from `workflows.json` and every run from `runs/<workflow_id>/<run_id>.json`, verify row counts match, sample-verify one row of each, COMMIT, then delete `workflows.json` and the entire `runs/` directory |
 
 Files inside `runs/` whose name is not a valid UUID `.json` filename (notably
@@ -611,8 +648,9 @@ the JSON sources are left untouched so the migration can be re-run after the
 underlying problem is fixed.  The error is propagated through
 `migration::run_pending()`, which aborts daemon startup.
 
-`migrations.json` is **not** moved into the `meta` table; it remains the
-canonical migration-state file alongside `acs.db` in the data directory.
+`migrations.json` is **not** moved into the `meta` table.  It remains on disk
+as the legacy migration-state file: the runner reads it once to backfill the
+`schema_migrations` tracking table and never touches it again.
 
 ### m003_drop_step_output_summary
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -108,7 +108,9 @@ CREATE TABLE workflows (
     last_run_status     TEXT,
     last_run_id         TEXT,
     created_at          TEXT NOT NULL,
-    updated_at          TEXT NOT NULL
+    updated_at          TEXT NOT NULL,
+    is_favorited        INTEGER NOT NULL DEFAULT 0,
+    deleted             INTEGER NOT NULL DEFAULT 0   -- soft-delete flag; added by m008 (v4.2.14)
 );
 
 CREATE TABLE workflow_runs (
@@ -474,6 +476,7 @@ On every `write_chunk(data)`:
 `acs/src/migration/m005_shell_claude_to_agent.rs`,
 `acs/src/migration/m006_agent_step_normalize.rs`,
 `acs/src/migration/m007_add_token_columns.rs`,
+`acs/src/migration/m008_add_workflow_deleted.rs`,
 `acs/src/migration/legacy_types.rs`
 
 ### Design
@@ -734,6 +737,29 @@ columns to the `workflow_runs` table introduced in v4.2.11. Both columns are
 | `acs.db` does not exist | No-op (return `Ok(false)`) — fresh install |
 | `total_input_tokens` column already present on `workflow_runs` | No-op (return `Ok(false)`) — idempotent |
 | Otherwise | BEGIN transaction → `ALTER TABLE workflow_runs ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0;` and `ALTER TABLE workflow_runs ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0;` → COMMIT |
+
+---
+
+### m008_add_workflow_deleted
+
+`m008_add_workflow_deleted` adds the `deleted` soft-delete column to the
+`workflows` table (v4.2.14, ACS-25). It is `INTEGER NOT NULL DEFAULT 0`, so
+existing workflows backfill to `0` ("not deleted"). Fresh installs receive the
+column directly via `schema.rs` and this migration short-circuits. No table
+rebuild, no new tables, no foreign-key changes.
+
+`DELETE /api/workflows/{id}` sets `deleted = 1` (keeping the row and every
+`workflow_runs` record so cost/token history survives) and rewrites the row's
+`name` to a tombstone (`"<name>\u{1}<id>"`) so the `UNIQUE` constraint on
+`workflows.name` no longer reserves the original name — this frees the name for
+reuse without dropping the constraint. Readers strip the tombstone so the
+displayed name stays the original.
+
+| Condition | Action |
+|---|---|
+| `acs.db` does not exist | No-op (return `Ok(false)`) — fresh install |
+| `deleted` column already present on `workflows` | No-op (return `Ok(false)`) — idempotent |
+| Otherwise | `ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;` |
 
 ---
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -92,7 +92,7 @@ Created idempotently by `apply_schema()` (every `CREATE TABLE` /
 ```sql
 CREATE TABLE workflows (
     id                  TEXT PRIMARY KEY,
-    name                TEXT NOT NULL UNIQUE,
+    name                TEXT NOT NULL,  -- uniqueness via idx_workflows_name_live (live rows only, v4.2.14)
     version             INTEGER NOT NULL,
     schedule            TEXT NOT NULL,
     timezone            TEXT,
@@ -112,6 +112,12 @@ CREATE TABLE workflows (
     is_favorited        INTEGER NOT NULL DEFAULT 0,
     deleted             INTEGER NOT NULL DEFAULT 0   -- soft-delete flag; added by m008 (v4.2.14)
 );
+
+-- Name uniqueness among LIVE workflows only (ACS-25, v4.2.14): soft-deleted
+-- rows are exempt, so a name becomes reusable after its owner is deleted
+-- while name resolution stays unambiguous.
+CREATE UNIQUE INDEX idx_workflows_name_live
+    ON workflows(name) WHERE deleted = 0;
 
 CREATE TABLE workflow_runs (
     run_id              TEXT PRIMARY KEY,
@@ -335,10 +341,12 @@ secondary sort.
 
 ### Indexes
 
-The `workflow_runs` table has three secondary indexes:
+The `workflows` table has one secondary index and the `workflow_runs` table
+has three:
 
 | Index | Columns | Purpose |
 |---|---|---|
+| `idx_workflows_name_live` | `(name) WHERE deleted = 0` (partial, unique) | Name uniqueness among **live** workflows only; soft-deleted rows are exempt so names are reusable after deletion (v4.2.14). |
 | `idx_workflow_runs_workflow_id_finished_at` | `(workflow_id, finished_at)` | Per-workflow listings ordered by completion time. |
 | `idx_workflow_runs_finished_at` | `(finished_at)` | Cross-workflow recency queries. |
 | `idx_workflow_runs_status` | `(status)` | Filters that pick out e.g. all currently-running rows. |
@@ -742,24 +750,37 @@ columns to the `workflow_runs` table introduced in v4.2.11. Both columns are
 
 ### m008_add_workflow_deleted
 
-`m008_add_workflow_deleted` adds the `deleted` soft-delete column to the
-`workflows` table (v4.2.14, ACS-25). It is `INTEGER NOT NULL DEFAULT 0`, so
-existing workflows backfill to `0` ("not deleted"). Fresh installs receive the
-column directly via `schema.rs` and this migration short-circuits. No table
-rebuild, no new tables, no foreign-key changes.
+`m008_add_workflow_deleted` (v4.2.14, ACS-25) adds the `deleted` soft-delete
+column to the `workflows` table and replaces the inline `UNIQUE` constraint on
+`name` with a **partial unique index** covering live rows only:
 
-`DELETE /api/workflows/{id}` sets `deleted = 1` (keeping the row and every
-`workflow_runs` record so cost/token history survives) and rewrites the row's
-`name` to a tombstone (`"<name>\u{1}<id>"`) so the `UNIQUE` constraint on
-`workflows.name` no longer reserves the original name — this frees the name for
-reuse without dropping the constraint. Readers strip the tombstone so the
-displayed name stays the original.
+```sql
+CREATE UNIQUE INDEX idx_workflows_name_live ON workflows(name) WHERE deleted = 0;
+```
+
+SQLite cannot drop an inline column constraint in place, so the migration
+performs a standard table rebuild inside a single transaction (with
+`PRAGMA foreign_keys = OFF` for its duration, toggled outside the transaction
+where the pragma actually takes effect): create `workflows_new` without the
+inline `UNIQUE`, copy all rows, drop the old table, rename, create the partial
+index, then run `PRAGMA foreign_key_check` and roll back if the rebuild would
+orphan any `workflow_runs` rows.
+
+`DELETE /api/workflows/{id}` sets `deleted = 1`, keeping the row (name stored
+verbatim) and every `workflow_runs` record so cost/token history survives.
+Because the unique index only covers `deleted = 0` rows, the name is
+immediately reusable by a new workflow while name resolution among live
+workflows stays unambiguous.
+
+Existing workflows backfill to `deleted = 0`. Fresh installs receive the new
+table shape and index directly via `schema.rs` and this migration
+short-circuits.
 
 | Condition | Action |
 |---|---|
 | `acs.db` does not exist | No-op (return `Ok(false)`) — fresh install |
-| `deleted` column already present on `workflows` | No-op (return `Ok(false)`) — idempotent |
-| Otherwise | `ALTER TABLE workflows ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;` |
+| `workflows` DDL no longer contains `UNIQUE` | No-op (return `Ok(false)`) — idempotent (already rebuilt or created fresh) |
+| Otherwise | Table rebuild: additively ensure `is_favorited`/`deleted` columns → `CREATE TABLE workflows_new` (no inline `UNIQUE`) → copy rows → `DROP`/`RENAME` → `CREATE UNIQUE INDEX idx_workflows_name_live ...` → `foreign_key_check` → COMMIT |
 
 ---
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -113,7 +113,7 @@ CREATE TABLE workflows (
     deleted             INTEGER NOT NULL DEFAULT 0   -- soft-delete flag; added by m008 (v4.2.14)
 );
 
--- Name uniqueness among LIVE workflows only (ACS-25, v4.2.14): soft-deleted
+-- Name uniqueness among LIVE workflows only (v4.2.14): soft-deleted
 -- rows are exempt, so a name becomes reusable after its owner is deleted
 -- while name resolution stays unambiguous.
 CREATE UNIQUE INDEX idx_workflows_name_live
@@ -750,7 +750,7 @@ columns to the `workflow_runs` table introduced in v4.2.11. Both columns are
 
 ### m008_add_workflow_deleted
 
-`m008_add_workflow_deleted` (v4.2.14, ACS-25) adds the `deleted` soft-delete
+`m008_add_workflow_deleted` (v4.2.14) adds the `deleted` soft-delete
 column to the `workflows` table and replaces the inline `UNIQUE` constraint on
 `name` with a **partial unique index** covering live rows only:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -46,7 +46,7 @@ files under `logs/`.  Migration execution is tracked in the
 ├── acs.db                      # SQLite database holding workflows + workflow_runs tables
 ├── acs.db-wal                  # SQLite write-ahead log (created at runtime, managed by SQLite)
 ├── acs.db-shm                  # SQLite shared memory file (created at runtime, managed by SQLite)
-├── migrations.json             # Legacy migration state; read once to backfill schema_migrations, never written again
+├── migrations.json             # Legacy migration state; read once to backfill schema_migrations, then deleted
 ├── jobs.json.migrated.<ts>     # Backup of legacy jobs.json after m001 runs (unix timestamp suffix)
 ├── migrated_scripts/           # Created on demand by m001 migration when migrating non-shell hooks
 ├── scripts/                    # Reserved directory (created on startup; not currently used)
@@ -205,10 +205,12 @@ writes from a crash never leave the database structurally inconsistent.
 Migration execution is tracked in the `schema_migrations` table inside
 `acs.db`, protected by the same SQLite atomicity guarantees as the data
 tables.  The legacy `migrations.json` file is read exactly once — to backfill
-the tracking table on databases that predate it.  If it is missing or
-contains invalid JSON at that moment, the backfill seeds nothing and every
-migration runs normally; each migration's internal idempotency makes that
-safe on an already-migrated database.
+the tracking table on databases that predate it — and deleted after a
+successful backfill (best-effort; a removal failure is only logged).  If it
+is missing or contains invalid JSON at that moment, the backfill seeds
+nothing and every migration runs normally; each migration's internal
+idempotency makes that safe on an already-migrated database.  A corrupt file
+is left in place for inspection.
 
 ---
 
@@ -515,6 +517,13 @@ value only affects logging.  The internal idempotency checks are a safety
 property (they make the delete-row-and-re-run workflow below harmless) — the
 runner never consults them to decide execution.
 
+Migrations are **frozen**: they carry their own private snapshot types for the
+data shapes they read and write (see the `frozen` modules in m001/m002 and
+`legacy_types.rs`) instead of referencing the live model structs.  Changes to
+the live models must never require editing an already-shipped migration —
+columns and JSON fields introduced after a migration's era are filled in by
+SQL `DEFAULT` clauses and serde defaults downstream.
+
 ### Tracking table: `schema_migrations`
 
 Migration execution is tracked by name in a `schema_migrations` table inside
@@ -577,9 +586,11 @@ for every registry migration named in that file — those are treated as
 already applied without being invoked.  Every other migration then runs
 normally; on an already-migrated database their internal idempotency makes
 that a safe no-op, recorded as `success`.  After this one-time backfill the
-table is the sole source of truth: `migrations.json` is left on disk but
-never written (or read) again.  A fresh install has no legacy file, so all
-migrations simply run once and end recorded as `success`.
+table is the sole source of truth and `migrations.json` is **deleted**
+(best-effort; a removal failure is only logged and can be cleaned up
+manually).  A corrupt legacy file seeds nothing and is left in place for
+inspection.  A fresh install has no legacy file, so all migrations simply
+run once and end recorded as `success`.
 
 ### Adding a migration
 
@@ -648,9 +659,10 @@ the JSON sources are left untouched so the migration can be re-run after the
 underlying problem is fixed.  The error is propagated through
 `migration::run_pending()`, which aborts daemon startup.
 
-`migrations.json` is **not** moved into the `meta` table.  It remains on disk
-as the legacy migration-state file: the runner reads it once to backfill the
-`schema_migrations` tracking table and never touches it again.
+`migrations.json` is **not** moved into the `meta` table.  It is the legacy
+migration-state file: the runner reads it once to backfill the
+`schema_migrations` tracking table and then deletes it.  This migration
+itself never touches the file.
 
 ### m003_drop_step_output_summary
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,6 +36,26 @@ agentcronsystem stop --force
 agentcronsystem start
 ```
 
+### Startup Aborts on a Failed Migration
+
+**Symptom:** The daemon exits immediately with an error like `Migration failed: Internal error: migration 'm008_add_workflow_deleted' previously failed and is blocking startup...` (or `migration '<name>' failed: <cause>. Startup aborted...` on the first occurrence).
+
+**Cause:** Database migrations are tracked by name in the `schema_migrations` table inside `acs.db`. When a migration fails, its row is recorded with `status = 'failed'` plus the error text, and every subsequent startup refuses to proceed — silently re-running against a half-migrated database could compound the damage.
+
+**Solution:**
+1. Read the recorded error to find the root cause:
+   ```
+   sqlite3 "{data_dir}/acs.db" "SELECT name, applied_at, error FROM schema_migrations WHERE status = 'failed';"
+   ```
+2. Fix the underlying issue (disk space, file permissions, corrupted source data, etc.). Back up `acs.db` first if the data matters.
+3. Delete the failed row so the next startup re-runs that migration:
+   ```
+   sqlite3 "{data_dir}/acs.db" "DELETE FROM schema_migrations WHERE name = '<migration name>';"
+   ```
+4. Restart the daemon: `agentcronsystem start`. The migration re-runs from the failed one onward; migrations that never got to run have no row and execute normally.
+
+Deleting a `success` row works the same way and forces that single migration to re-run — safe, because every migration is internally idempotent. See [Storage — Migration System](storage.md#9-migration-system) for the full runner semantics.
+
 ### Port Already in Use
 
 **Symptom:** Error message `Failed to bind to 127.0.0.1:8377` when starting the daemon.

--- a/docs/workflow-management.md
+++ b/docs/workflow-management.md
@@ -35,6 +35,8 @@ Each workflow run executes its steps in sequence. Steps can spawn subprocesses, 
 | `last_run_status` | `Option<RunStatus>` | `null` | Status of the most recent completed run. Set by the daemon. |
 | `last_run_id` | `Option<Uuid>` | `null` | Run ID of the most recent run. Set by the daemon. |
 | `next_run_at` | `Option<DateTime<Utc>>` | `null` | Computed at runtime; never persisted. Only present in GET responses. |
+| `is_favorited` | `bool` | `false` | Whether the workflow is pinned to the top of UI list views. Does not bump `version`. |
+| `deleted` | `bool` | `false` | Soft-delete flag (v4.2.14). When `true` the workflow is hidden from list/resolve/schedule/trigger, but its row and runs persist. See [Deletion](#deletion-soft-delete). |
 | `created_at` | `DateTime<Utc>` | auto | Timestamp of creation. |
 | `updated_at` | `DateTime<Utc>` | auto | Timestamp of last update. |
 
@@ -54,6 +56,33 @@ Updatable: `name`, `schedule`, `timezone`, `schedule_mode`, `enabled`, `steps`, 
 
 Sending `null` for `timezone`, `working_dir`, or `default_input` in a PATCH body is treated the same as omitting the field — the existing value is unchanged. Send a non-null value to update them.
 
+### Deletion (soft delete)
+
+`DELETE /api/workflows/{id}` performs a **soft delete** (v4.2.14, ACS-25): the
+workflow row and **all** of its runs are kept — the `workflow_runs` rows are the
+cost/token record and must survive — and the workflow is flagged `deleted`.
+
+After deletion the workflow:
+
+- is excluded from `GET /api/workflows`, name resolution, the scheduler, and
+  triggering (all behave as `404`);
+- has its **name freed for reuse** — a new workflow can be created with the same
+  name. The old and new workflows remain distinct rows keyed by `id`, so cost
+  views list them separately;
+- keeps its runs readable via `GET /api/runs/{run_id}`, and its cost history
+  visible via the cost endpoints (flagged `workflow_deleted: true`).
+
+**Active-run guard.** If the workflow has a run currently `Running`, the delete
+is rejected with `409 Conflict` (`error: "workflow_run_active"`). Kill or wait
+for the run to finish, then retry.
+
+**On-disk cleanup (best-effort).** After the DB update succeeds, the run-log
+directory `<data_dir>/logs/<workflow_id>/` is removed, and the operating folder
+is removed **only** when it is the ACS-managed default path
+(`<user-documents>/agent-cron-scheduler/<sanitized-name>/` or the configured
+`display_workflow_dir_root` equivalent). A custom, user-specified `working_dir`
+is **never** touched. Cleanup failures are logged and never fail the request.
+
 ---
 
 ## Validation Rules
@@ -68,6 +97,10 @@ Validation runs on both `NewWorkflow` and `WorkflowUpdate` before any changes ar
 | Name must not be a valid UUID string. | `"Workflow name cannot be a valid UUID"` |
 
 The UUID restriction prevents ambiguity when referencing workflows by name or ID in CLI commands and API routes.
+
+Names must be unique **among live workflows**. Soft-deleted workflows (see
+[Deletion](#deletion-soft-delete)) are excluded from the uniqueness check, so a
+name becomes available for reuse once its owner is deleted.
 
 ### Cron expression validation
 

--- a/docs/workflow-management.md
+++ b/docs/workflow-management.md
@@ -58,7 +58,7 @@ Sending `null` for `timezone`, `working_dir`, or `default_input` in a PATCH body
 
 ### Deletion (soft delete)
 
-`DELETE /api/workflows/{id}` performs a **soft delete** (v4.2.14, ACS-25): the
+`DELETE /api/workflows/{id}` performs a **soft delete** (v4.2.14): the
 workflow row and **all** of its runs are kept — the `workflow_runs` rows are the
 cost/token record and must survive — and the workflow is flagged `deleted`.
 

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acs-electron",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acs-electron",
-      "version": "4.2.13",
+      "version": "4.2.14",
       "workspaces": [
         "packages/*"
       ],
@@ -16270,7 +16270,7 @@
     },
     "packages/app": {
       "name": "@acs/app",
-      "version": "4.2.13",
+      "version": "4.2.14",
       "devDependencies": {
         "electron": "33.4.11",
         "electron-builder": "^26.0.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-electron",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "private": true,
   "//workspaces": "desktopapp is excluded so it installs standalone (own node_modules + package-lock.json) and `npm install` / `npm run dev` work from inside its folder. It also has outputFileTracingRoot pinned in its next.config.ts so Next doesn't walk up to this lockfile.",
   "workspaces": [

--- a/electron/packages/app/package.json
+++ b/electron/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acs/app",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "private": true,
   "description": "Agent Cron Scheduler desktop application",
   "author": "Jtonna",


### PR DESCRIPTION
## Summary

Fixes `DELETE /api/workflows/{id}` returning `500 {"error":"internal_error","message":"Storage error: FOREIGN KEY constraint failed"}` for any workflow with run history.

Approved design v2 — **soft delete**. Cost/token bookkeeping must survive workflow deletion: the `workflow_runs` rows ARE the cost record and persist; disk artifacts are truly deleted; the only trace of a deleted workflow is its flagged DB row + its run metrics.

Ticket: https://linear.app/jtonna/issue/ACS-25/delete-apiworkflowsid-returns-500-fk-constraint-once-run-history

## What changed

- **Migration m008** — schema rebuild + soft-delete column: recreates the `workflows` table **without** the inline `UNIQUE` on `name` (standard SQLite rebuild in one transaction, `foreign_keys OFF` for its duration, `foreign_key_check` before COMMIT), adds `deleted INTEGER NOT NULL DEFAULT 0`, and creates a **partial unique index**:
  ```sql
  CREATE UNIQUE INDEX idx_workflows_name_live ON workflows(name) WHERE deleted = 0;
  ```
  Names stay unique among **live** workflows (name resolution stays unambiguous); soft-deleted rows are exempt, so a deleted workflow's name is immediately reusable and **deleted rows keep their name verbatim**. Fresh-install `schema.rs` matches (no inline `UNIQUE`, same index).
- **Soft-delete semantics** — `DELETE` sets `deleted=1`, keeps the row and ALL runs, returns 204. Returns **409** (`workflow_run_active`) if a run is `Running`. Best-effort disk cleanup after the DB update: removes `<data_dir>/logs/<id>/` and the operating folder **only** when it equals the ACS-managed default path — a custom `working_dir` is never touched.
- **Exclusions** — deleted workflows are excluded from list / name-resolution / scheduler / trigger / GET-by-id / PATCH / favorite (all behave as 404). Runs stay queryable via `GET /api/runs/{run_id}`; the run-log endpoint 404s (never 500s) once files are gone.
- **Name reuse** — uniqueness checks + resolution exclude deleted rows; a duplicate **live** name still maps to a structured 409 via the partial index's constraint violation. Cost views key by `workflow_id`, so a deleted and a new same-name workflow stay separate entries.
- **Cost endpoints** — `GET /api/cost/workflows[/{id}]` include deleted workflows, each flagged `workflow_deleted: true` (false for live). Per-id endpoint returns 200 for a deleted workflow.
- **Error mapping** — `map_store_error` maps constraint/FK Storage errors to a structured 409 instead of the 500 catch-all.
- **Test-suite fix (caught issue, own commit)** — four cost-summary unit tests hardcoded a fixed "recent" timestamp and rotted out of the rolling 30-day window (they were failing on the base branch). Those and three other latent cases now compute timestamps relative to `Utc::now()`. Deliberate fixed-date tests (explicit-window daily-bucket tests, DST spring-forward pin) are untouched.
- **Docs + version** — api-reference.md, storage.md, workflow-management.md, troubleshooting.md, openapi.yaml updated; version bumped 4.2.13 → 4.2.14 across the historically bumped files.

## Migration run tracking (`schema_migrations`)

Migration execution is no longer introspection-driven — migrations are frozen and tracked by name in the database, Flyway-style:

- **Tracking table**, created by the **runner itself** (not a migration) before any migration logic runs:
  ```sql
  CREATE TABLE schema_migrations (
      name        TEXT PRIMARY KEY,
      applied_at  TEXT NOT NULL,
      status      TEXT NOT NULL CHECK (status IN ('success','failed')),
      duration_ms INTEGER,
      error       TEXT
  );
  ```
- **Runner semantics** — the registry (m001..m008) is walked in order; the table alone decides execution: no row → run and record `success`/`failed`; `success` row → skip without invoking; `failed` row → **abort startup** with an actionable error naming the migration (fix the issue, then `DELETE FROM schema_migrations WHERE name = '...'` to re-run — the sanctioned recovery workflow, documented in storage.md + troubleshooting.md). A no-op run still records `success` ("processed"). On failure the error text is recorded and later migrations do not run.
- **Backfill for existing databases** — the first time the runner creates the table, the legacy `migrations.json` applied-set seeds `success` rows for those names (not invoked); everything else runs normally, with per-migration internal idempotency making that safe on already-migrated databases. After the one-time backfill the table is the sole source of truth and **`migrations.json` is deleted** (best-effort; a corrupt file seeds nothing and is left in place for inspection). A fresh install ends with all 8 migrations recorded as `success`.
- **Frozen migrations** — m001/m002 carry their own private snapshot types (`frozen` modules + a frozen `legacy_types`) for the exact data shapes they read and write; their production code no longer references the live model structs. Inserts list only the columns of each migration's schema era — later columns (`is_favorited`, `deleted`, token counts) are filled by SQL `DEFAULT` clauses, and later JSON fields by serde defaults downstream. Live-model changes can never again force edits to shipped migrations.
- **Internal idempotency checks stay** inside migrations purely as safety for delete-row-and-re-run; the runner never consults them. m002's already-applied check became table-based (`workflows` table present) instead of file-based, since the runner now creates `acs.db` up front.
- **Startup logging** distinguishes seeded / applied / processed-no-op / skipped.

## Test evidence

Run with the mandatory skip (see below), `cargo test --no-fail-fast -- --skip test_executor_agent_step_dispatched`:

- lib: **583 passed, 0 failed**, 1 filtered (executor skip)
- `cli_tests`: **9 passed, 0 failed**
- `workflow_api_tests`: **78 passed, 0 failed** (incl. 6 soft-delete integration tests)
- **Suite total: 670 passed, 0 failures**
- `cargo clippy -- -D warnings` — clean
- `cargo fmt -- --check` — clean

New tests: 6 storage unit tests (soft-delete exclusion, including-deleted accessors, name reuse, idempotent re-delete, update/favorite-on-deleted 404), 5 m008 migration tests (rebuild removes inline UNIQUE + adds column/index, row + FK preservation, idempotency, post-migration name-reuse semantics, column shape), 3 schema tests, 6 API integration tests, and **12 migration-runner tests** (fresh run-once-then-skip, backfill seed/run split + one-time-only + unknown-name handling + legacy-file deletion + corrupt-file-left-in-place, deleted-row re-run, failure recording + startup blocking + recovery-after-delete, registry ordering, real-registry fresh install / legacy backfill / lost-state-file).

### ⚠️ Executor test skip (ACS-26)
`test_executor_agent_step_dispatched` is skipped via `-- --skip test_executor_agent_step_dispatched` because it spawns a real `claude -p ... --dangerously-skip-permissions` session when the CLI is on PATH (real cost / recursion risk). Untouched here; tracked as ACS-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)